### PR TITLE
feat(server): enable fxa oauth login + save to db

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -10,7 +10,7 @@
     "requireCurlyBraces": ["for", "while", "do"],
     "requireLineFeedAtFileEnd": true,
     "requireSpaceAfterBinaryOperators": ["=", ",", "+", "-", "/", "*", "==", "===", "!=", "!=="],
-    "requireSpaceAfterKeywords": ["if", "else", "for", "function", "while", "do", "switch", "return"],
+    "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return"],
     "requireSpaceAfterPrefixUnaryOperators": ["~"],
     "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
     "requireSpacesInConditionalExpression": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,6 @@
   "sub": true,
   "trailing": true,
   "undef": true,
-  "unused": true,
   "globals": {
     "define": false,
     "Promise": true

--- a/config/local.json.example
+++ b/config/local.json.example
@@ -8,7 +8,8 @@
       "host": "127.0.0.1",
       "port": 3306,
       "user": "root",
-      "password": ""
+      "password": "",
+      "database": "chronicle"
     },
     "redis": {
       "host": "127.0.0.1",
@@ -17,13 +18,31 @@
   },
   "env": "local",
   "server": {
+    "host": "127.0.0.1",
+    "port": 8080,
+    "staticPath": "dist",
+    "staticDirListing": true,
     "log": {
       "app": "chronicle",
-      "debug": true,
+      "debug": false,
       "fmt": "pretty",
       "level": "verbose"
     },
-    "host": "127.0.0.1",
-    "port": 8080
+    "session": {
+      "password": "Wh4t3ver.",
+      "isSecure": false,
+      "duration": "7 days"
+    },
+    "oauth": {
+      "clientId": "1f9bbddcb3e160ab",
+      "clientSecret": "24bf8caeaa685e2e42d9a75b48511f83adffaf6fcdd174ce8749358a376be911",
+      "scope": ["chronicle", "profile"],
+      "version": "2.0",
+      "protocol": "oauth2",
+      "redirectEndpoint": "http://localhost:8080/auth/complete",
+      "authEndpoint": "https://oauth-latest.dev.lcip.org/v1/authorization",
+      "tokenEndpoint": "https://oauth-latest.dev.lcip.org/v1/token",
+      "profileEndpoint": "https://latest.dev.lcip.org/profile/v1/profile"
+    }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,55 @@
   "name": "mozilla-chronicle",
   "version": "0.1.0",
   "dependencies": {
+    "bell": {
+      "version": "2.0.0",
+      "from": "bell@2.0.0",
+      "resolved": "https://registry.npmjs.org/bell/-/bell-2.0.0.tgz",
+      "dependencies": {
+        "boom": {
+          "version": "2.6.1",
+          "from": "boom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.4",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+        },
+        "hoek": {
+          "version": "2.10.0",
+          "from": "hoek@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
+        },
+        "joi": {
+          "version": "5.0.2",
+          "from": "joi@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
+          "dependencies": {
+            "topo": {
+              "version": "1.0.2",
+              "from": "topo@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
+            },
+            "isemail": {
+              "version": "1.1.1",
+              "from": "isemail@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+            },
+            "moment": {
+              "version": "2.8.4",
+              "from": "moment@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "buf": {
+      "version": "0.1.0",
+      "from": "buf@0.1.0",
+      "resolved": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz"
+    },
     "convict": {
       "version": "0.6.0",
       "from": "convict@0.6.0",
@@ -19,32 +68,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -53,7 +102,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -77,12 +126,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -96,22 +145,22 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@0.4.5",
+      "from": "grunt@>=0.4.4 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -121,37 +170,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -160,1634 +209,147 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.8",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
-        }
-      }
-    },
-    "grunt-autoprefixer": {
-      "version": "2.0.0",
-      "from": "grunt-autoprefixer@2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.0.0.tgz",
-      "dependencies": {
-        "autoprefixer-core": {
-          "version": "4.0.2",
-          "from": "autoprefixer-core@^4.0.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-4.0.2.tgz",
-          "dependencies": {
-            "caniuse-db": {
-              "version": "1.0.30000033",
-              "from": "caniuse-db@^1.0.30000030",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000033.tgz"
-            },
-            "postcss": {
-              "version": "3.0.7",
-              "from": "postcss@~3.0.6",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-3.0.7.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.41",
-                  "from": "source-map@~0.1.40",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                    }
-                  }
-                },
-                "js-base64": {
-                  "version": "2.1.5",
-                  "from": "js-base64@~2.1.5",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "diff": {
-          "version": "1.0.8",
-          "from": "diff@~1.0.8",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-contrib-clean": {
-      "version": "0.6.0",
-      "from": "grunt-contrib-clean@0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@~2.2.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        }
-      }
-    },
-    "grunt-contrib-copy": {
-      "version": "0.7.0",
-      "from": "grunt-contrib-copy@0.7.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.7.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-contrib-jshint": {
-      "version": "0.10.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
-      "dependencies": {
-        "hooker": {
-          "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        }
-      }
-    },
-    "grunt-contrib-watch": {
-      "version": "0.6.1",
-      "from": "grunt-contrib-watch@0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "dependencies": {
-        "gaze": {
-          "version": "0.5.1",
-          "from": "gaze@~0.5.1",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "globule@~0.1.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.1",
-                  "from": "lodash@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "glob@~3.1.21",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "inherits@1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tiny-lr-fork": {
-          "version": "0.0.5",
-          "from": "tiny-lr-fork@0.0.5",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "qs@~0.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
-            },
-            "faye-websocket": {
-              "version": "0.4.4",
-              "from": "faye-websocket@~0.4.3",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-            },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "noptify@~0.0.3",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "nopt@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@~0.7.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "async@~0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        }
-      }
-    },
-    "grunt-conventional-changelog": {
-      "version": "1.1.0",
-      "from": "grunt-conventional-changelog@1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.1.0.tgz",
-      "dependencies": {
-        "conventional-changelog": {
-          "version": "0.0.6",
-          "from": "conventional-changelog@0.0.6",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
-          "dependencies": {
-            "lodash.assign": {
-              "version": "2.4.1",
-              "from": "lodash.assign@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-              "dependencies": {
-                "lodash._basecreatecallback": {
-                  "version": "2.4.1",
-                  "from": "lodash._basecreatecallback@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash.bind": {
-                      "version": "2.4.1",
-                      "from": "lodash.bind@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._createwrapper": {
-                          "version": "2.4.1",
-                          "from": "lodash._createwrapper@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._basebind": {
-                              "version": "2.4.1",
-                              "from": "lodash._basebind@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._basecreate": {
-                                  "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                                  "dependencies": {
-                                    "lodash._isnative": {
-                                      "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                    },
-                                    "lodash.noop": {
-                                      "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                    }
-                                  }
-                                },
-                                "lodash.isobject": {
-                                  "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash._basecreatewrapper": {
-                              "version": "2.4.1",
-                              "from": "lodash._basecreatewrapper@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._basecreate": {
-                                  "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                                  "dependencies": {
-                                    "lodash._isnative": {
-                                      "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                    },
-                                    "lodash.noop": {
-                                      "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                    }
-                                  }
-                                },
-                                "lodash.isobject": {
-                                  "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash.isfunction": {
-                              "version": "2.4.1",
-                              "from": "lodash.isfunction@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-                            }
-                          }
-                        },
-                        "lodash._slice": {
-                          "version": "2.4.1",
-                          "from": "lodash._slice@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.identity": {
-                      "version": "2.4.1",
-                      "from": "lodash.identity@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
-                    },
-                    "lodash._setbinddata": {
-                      "version": "2.4.1",
-                      "from": "lodash._setbinddata@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash.noop": {
-                          "version": "2.4.1",
-                          "from": "lodash.noop@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.support": {
-                      "version": "2.4.1",
-                      "from": "lodash.support@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash.keys": {
-                  "version": "2.4.1",
-                  "from": "lodash.keys@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "lodash._isnative@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    },
-                    "lodash.isobject": {
-                      "version": "2.4.1",
-                      "from": "lodash.isobject@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "from": "lodash._shimkeys@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash._objecttypes": {
-                  "version": "2.4.1",
-                  "from": "lodash._objecttypes@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                }
-              }
-            },
-            "event-stream": {
-              "version": "3.1.7",
-              "from": "event-stream@~3.1.0",
-              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-              "dependencies": {
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                },
-                "duplexer": {
-                  "version": "0.1.1",
-                  "from": "duplexer@~0.1.1",
-                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-                },
-                "from": {
-                  "version": "0.1.3",
-                  "from": "from@~0",
-                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-                },
-                "map-stream": {
-                  "version": "0.1.0",
-                  "from": "map-stream@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-                },
-                "pause-stream": {
-                  "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
-                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-                },
-                "split": {
-                  "version": "0.2.10",
-                  "from": "split@0.2",
-                  "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
-                },
-                "stream-combiner": {
-                  "version": "0.0.4",
-                  "from": "stream-combiner@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "grunt-copyright": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
-    },
-    "grunt-git-contributors": {
-      "version": "0.1.5",
-      "from": "grunt-git-contributors@0.1.5",
-      "resolved": "https://registry.npmjs.org/grunt-git-contributors/-/grunt-git-contributors-0.1.5.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "2.2.1",
-          "from": "lodash@~2.2.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
-        }
-      }
-    },
-    "grunt-jscs": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.0.0.tgz",
-      "dependencies": {
-        "hooker": {
-          "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "jscs": {
-          "version": "1.8.1",
-          "from": "https://registry.npmjs.org/jscs/-/jscs-1.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.8.1.tgz",
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            },
-            "commander": {
-              "version": "2.5.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
-            },
-            "esprima": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
-            },
-            "esprima-harmony-jscs": {
-              "version": "1.1.0-dev-harmony",
-              "from": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz"
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "glob": {
-              "version": "4.0.6",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.5",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "vow-fs": {
-              "version": "0.3.3",
-              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.3.tgz",
-              "dependencies": {
-                "node-uuid": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz"
-                },
-                "vow": {
-                  "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/vow/-/vow-0.4.4.tgz",
-                  "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.4.tgz"
-                },
-                "vow-queue": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
-                },
-                "glob": {
-                  "version": "3.2.8",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "xmlbuilder": {
-              "version": "2.4.5",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.5.tgz",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.5.tgz",
-              "dependencies": {
-                "lodash-node": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "vow": {
-          "version": "0.4.7",
-          "from": "https://registry.npmjs.org/vow/-/vow-0.4.7.tgz",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.7.tgz"
-        }
-      }
-    },
-    "grunt-jsonlint": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
-      "dependencies": {
-        "jsonlint": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
-          "dependencies": {
-            "nomnom": {
-              "version": "1.8.1",
-              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-                },
-                "chalk": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                  "dependencies": {
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "JSV": {
-              "version": "4.0.2",
-              "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-nsp-shrinkwrap": {
-      "version": "0.0.3",
-      "from": "grunt-nsp-shrinkwrap@0.0.3",
-      "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
-      "dependencies": {
-        "cli-color": {
-          "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
-          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-          "dependencies": {
-            "es5-ext": {
-              "version": "0.9.2",
-              "from": "es5-ext@~0.9.2",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
-            },
-            "memoizee": {
-              "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
-              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-              "dependencies": {
-                "event-emitter": {
-                  "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
-                },
-                "next-tick": {
-                  "version": "0.1.0",
-                  "from": "next-tick@0.1.x",
-                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "colors": {
-          "version": "0.6.2",
-          "from": "colors@^0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-        },
-        "request": {
-          "version": "2.51.0",
-          "from": "request@^2.34.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-          "dependencies": {
-            "bl": {
-              "version": "0.9.3",
-              "from": "bl@~0.9.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.8.0",
-              "from": "caseless@~0.8.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "from": "forever-agent@~0.5.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@~0.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.0",
-                  "from": "async@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.0.4",
-                  "from": "mime-types@~2.0.3",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.3.1",
-                      "from": "mime-db@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-            },
-            "mime-types": {
-              "version": "1.0.2",
-              "from": "mime-types@~1.0.1",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "qs@~2.3.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-            },
-            "tough-cookie": {
-              "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.10.0",
-              "from": "http-signature@~0.10.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.2",
-                  "from": "assert-plus@0.1.2",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.2",
-                  "from": "ctype@0.5.2",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.5.0",
-              "from": "oauth-sign@~0.5.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-            },
-            "hawk": {
-              "version": "1.1.1",
-              "from": "hawk@1.1.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "0.9.1",
-                  "from": "hoek@0.9.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                },
-                "boom": {
-                  "version": "0.4.2",
-                  "from": "boom@0.4.x",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                },
-                "cryptiles": {
-                  "version": "0.2.2",
-                  "from": "cryptiles@0.2.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                },
-                "sntp": {
-                  "version": "0.2.4",
-                  "from": "sntp@0.2.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@~0.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@^0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "grunt-sass": {
-      "version": "0.17.0",
-      "from": "grunt-sass@0.17.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.17.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "each-async": {
-          "version": "1.1.0",
-          "from": "each-async@^1.0.0",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.0.tgz",
-          "dependencies": {
-            "onetime": {
-              "version": "1.0.0",
-              "from": "onetime@^1.0.0",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
-            },
-            "setimmediate": {
-              "version": "1.0.2",
-              "from": "setimmediate@^1.0.2",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz"
-            }
-          }
-        },
-        "node-sass": {
-          "version": "1.2.3",
-          "from": "node-sass@1.2.3",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-1.2.3.tgz",
-          "dependencies": {
-            "cross-spawn": {
-              "version": "0.2.3",
-              "from": "cross-spawn@^0.2.3",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.3.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@^2.5.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                }
-              }
-            },
-            "gaze": {
-              "version": "0.5.1",
-              "from": "gaze@^0.5.1",
-              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-              "dependencies": {
-                "globule": {
-                  "version": "0.1.0",
-                  "from": "globule@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "1.0.1",
-                      "from": "lodash@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
-                    },
-                    "glob": {
-                      "version": "3.1.21",
-                      "from": "glob@~3.1.21",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@~1.2.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                        },
-                        "inherits": {
-                          "version": "1.0.0",
-                          "from": "inherits@1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "get-stdin": {
-              "version": "3.0.2",
-              "from": "get-stdin@^3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-            },
-            "meow": {
-              "version": "2.0.0",
-              "from": "meow@^2.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.0.2",
-                      "from": "camelcase@^1.0.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.0",
-                      "from": "map-obj@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                    }
-                  }
-                },
-                "indent-string": {
-                  "version": "1.2.0",
-                  "from": "indent-string@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "1.1.0",
-                      "from": "repeating@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.0.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.0",
-                          "from": "is-finite@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                        },
-                        "meow": {
-                          "version": "1.0.0",
-                          "from": "meow@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/meow/-/meow-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "1.1.0",
-                  "from": "minimist@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@^0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "mocha": {
-              "version": "2.0.1",
-              "from": "mocha@^2.0.1",
-              "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.3.0",
-                  "from": "commander@2.3.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-                },
-                "debug": {
-                  "version": "2.0.0",
-                  "from": "debug@2.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "diff": {
-                  "version": "1.0.8",
-                  "from": "diff@1.0.8",
-                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.2",
-                  "from": "escape-string-regexp@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.2.3",
-                  "from": "glob@3.2.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "growl": {
-                  "version": "1.8.1",
-                  "from": "growl@1.8.1",
-                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
-                },
-                "jade": {
-                  "version": "0.26.3",
-                  "from": "jade@0.26.3",
-                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "nan": {
-              "version": "1.4.1",
-              "from": "nan@^1.3.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
-            },
-            "object-assign": {
-              "version": "1.0.0",
-              "from": "object-assign@^1.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "request": {
-              "version": "2.51.0",
-              "from": "request@^2.48.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "0.9.3",
-                  "from": "bl@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.8.0",
-                  "from": "caseless@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                },
-                "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.9.0",
-                      "from": "async@~0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.0.4",
-                      "from": "mime-types@~2.0.3",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.3.1",
-                          "from": "mime-db@~1.3.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-                },
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                },
-                "tough-cookie": {
-                  "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.2",
-                      "from": "assert-plus@0.1.2",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.2",
-                      "from": "ctype@0.5.2",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.5.0",
-                  "from": "oauth-sign@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-                },
-                "hawk": {
-                  "version": "1.1.1",
-                  "from": "hawk@1.1.1",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@0.9.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@^0.3.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "object-assign@^2.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         }
       }
     },
@@ -1823,17 +385,17 @@
           "dependencies": {
             "joi": {
               "version": "4.9.0",
-              "from": "joi@4.x.x",
+              "from": "joi@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "isemail@1.x.x",
+                  "from": "isemail@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "moment@2.x.x",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 }
               }
@@ -1994,267 +556,56 @@
         }
       }
     },
-    "jshint": {
-      "version": "2.5.10",
-      "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
+    "hapi-auth-cookie": {
+      "version": "2.0.0",
+      "from": "hapi-auth-cookie@2.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-auth-cookie/-/hapi-auth-cookie-2.0.0.tgz",
       "dependencies": {
-        "cli": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "boom": {
+          "version": "2.6.1",
+          "from": "boom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "dependencies": {
-            "date-now": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-            }
-          }
-        },
-        "exit": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-        },
-        "htmlparser2": {
-          "version": "3.8.2",
-          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-          "dependencies": {
-            "domhandler": {
-              "version": "2.3.0",
-              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-            },
-            "domutils": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
-            },
-            "domelementtype": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-            },
-            "sigmund": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-        },
-        "underscore": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "jshint-stylish": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
-        },
-        "string-length": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
-          "dependencies": {
-            "strip-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        "hoek": {
+          "version": "2.10.0",
+          "from": "hoek@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
         }
       }
     },
     "load-grunt-tasks": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-1.0.0.tgz",
+      "from": "load-grunt-tasks@1.0.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-1.0.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2263,46 +614,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-1.0.1.tgz",
+          "from": "multimatch@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-1.0.1.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "from": "array-differ@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "from": "array-union@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "from": "minimatch@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -2323,78 +674,78 @@
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.1",
+              "from": "dbug@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "depd": {
               "version": "1.0.0",
-              "from": "depd@~1.0.0",
+              "from": "depd@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "strftime@~0.8.0",
+              "from": "strftime@>=0.8.0 <0.9.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
@@ -2418,12 +769,12 @@
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@~1.1.13",
+          "from": "readable-stream@>=1.1.13 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
@@ -2433,12 +784,12 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@~0.10.x",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -2450,79 +801,27 @@
         }
       }
     },
-    "precommit-hook": {
-      "version": "1.0.7",
-      "from": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz"
-    },
-    "sequelize": {
-      "version": "2.0.0-rc3",
-      "from": "sequelize@2.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-2.0.0-rc3.tgz",
-      "dependencies": {
-        "bluebird": {
-          "version": "2.3.11",
-          "from": "bluebird@~2.3.11",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.11.tgz"
-        },
-        "dottie": {
-          "version": "0.2.4",
-          "from": "dottie@0.2.4",
-          "resolved": "https://registry.npmjs.org/dottie/-/dottie-0.2.4.tgz"
-        },
-        "generic-pool": {
-          "version": "2.1.1",
-          "from": "generic-pool@2.1.1",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
-        },
-        "inflection": {
-          "version": "1.5.2",
-          "from": "inflection@1.5.2",
-          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.5.2.tgz"
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "moment": {
-          "version": "2.8.4",
-          "from": "moment@~2.8.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
-        },
-        "node-uuid": {
-          "version": "1.4.2",
-          "from": "node-uuid@~1.4.1",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-        },
-        "pg-hstore": {
-          "version": "2.2.0",
-          "from": "pg-hstore@^2.2.0",
-          "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.2.0.tgz",
-          "dependencies": {
-            "underscore": {
-              "version": "1.7.0",
-              "from": "underscore@*",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-            }
-          }
-        },
-        "toposort-class": {
-          "version": "0.3.1",
-          "from": "toposort-class@~0.3.0",
-          "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-0.3.1.tgz"
-        },
-        "validator": {
-          "version": "3.22.2",
-          "from": "validator@~3.22.1",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.2.tgz"
-        }
-      }
-    },
     "uuid": {
       "version": "2.0.1",
       "from": "uuid@2.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+    },
+    "wreck": {
+      "version": "5.1.0",
+      "from": "wreck@5.1.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.1.0.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "2.10.0",
+          "from": "hoek@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
+        },
+        "boom": {
+          "version": "2.6.1",
+          "from": "boom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "url": "https://github.com/mozilla/chronicle/issues"
   },
   "dependencies": {
+    "bell": "2.0.0",
+    "buf": "0.1.0",
     "convict": "0.6.0",
     "hapi": "8.0.0",
+    "hapi-auth-cookie": "2.0.0",
     "load-grunt-tasks": "1.0.0",
     "mozlog": "1.0.0",
     "mysql": "2.5.3",
-    "sequelize": "2.0.0-rc3",
-    "uuid": "2.0.1"
+    "uuid": "2.0.1",
+    "wreck": "5.1.0"
   },
   "devDependencies": {
     "grunt-autoprefixer": "2.0.0",

--- a/server/config.js
+++ b/server/config.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 
@@ -41,6 +43,16 @@ var conf = convict({
       password: {
         default: '',
         env: 'MYSQL_PASSWORD'
+      },
+      database: {
+        doc: 'Name of the database.',
+        default: 'chronicle',
+        env: 'MYSQL_DATABASE'
+      },
+      connectionLimit: {
+        doc: 'Max number of MySQL workers in the pool.',
+        default: 25,
+        env: 'MYSQL_CONN_LIMIT'
       }
     },
     redis: {
@@ -72,7 +84,7 @@ var conf = convict({
       },
       debug: {
         doc: 'Extra checks that logger invocations are correct. Useful when developing',
-        default: true
+        default: false
       }
     },
     host: {
@@ -87,8 +99,78 @@ var conf = convict({
     },
     staticPath: {
       doc: 'Path to static files.',
-      default: 'app',
+      default: 'dist',
       env: 'STATIC_PATH'
+    },
+    staticDirListing: {
+      doc: 'Whether to allow directory listings for static dirs.',
+      default: false,
+      env: 'STATIC_DIR_LISTING'
+    },
+    oauth: {
+      clientId: {
+        doc: 'Firefox Accounts client_id.',
+        default: '5901bd09376fadaa',
+        env: 'FXA_OAUTH_CLIENT_ID'
+      },
+      clientSecret: {
+        doc: 'Firefox Accounts OAuth client_secret.',
+        default: '4ab433e31ef3a7cf7c20590f047987922b5c9ceb1faff56f0f8164df053dd94c',
+        env: 'FXA_OAUTH_CLIENT_SECRET'
+      },
+      scope: {
+        doc: 'Application scope. Currently not checked by the auth server.',
+        default: ['chronicle', 'profile'],
+        env: 'FXA_OAUTH_SCOPE'
+      },
+      version: {
+        doc: 'OAuth version.',
+        default: '2.0',
+        env: 'FXA_OAUTH_VERSION'
+      },
+      protocol: {
+        doc: 'OAuth authorization protocol used.',
+        default: 'oauth2',
+        env: 'FXA_OAUTH_AUTH_PROTOCOL'
+      },
+      redirectEndpoint: {
+        doc: 'App endpoint to which OAuth flow redirects.',
+        default: 'http://localhost:8080/auth/complete',
+        env: 'FXA_OAUTH_REDIRECT_ENDPOINT'
+      },
+      authEndpoint: {
+        doc: 'Firefox Accounts OAuth authorization endpoint.',
+        default: 'https://oauth-latest.dev.lcip.org/v1/authorization',
+        env: 'FXA_OAUTH_AUTH_ENDPOINT'
+      },
+      tokenEndpoint: {
+        doc: 'Firefox Accounts OAuth token endpoint.',
+        default: 'https://oauth-latest.dev.lcip.org/v1/token',
+        env: 'FXA_OAUTH_TOKEN_ENDPOINT'
+      },
+      profileEndpoint: {
+        doc: 'Firefox Accounts profile server endpoint, used to fetch email, fxa_id.',
+        default: 'https://latest.dev.lcip.org/profile/v1/profile',
+        env: 'FXA_PROFILE_ENDPOINT'
+      }
+    },
+    session: {
+      password: {
+        doc: 'Password used to encrypt cookies with hueniverse-iron.',
+        default: 'S3kr1t',
+        env: 'SESSION_PASSWORD'
+      },
+      isSecure: {
+        doc: 'Whether to allow cookie to be transmitted over insecure connections.',
+        default: false,
+        env: 'SESSION_ALLOW_INSECURE_COOKIES'
+      },
+      duration: {
+        doc: 'Default session TTL for authenticated users.',
+        format: 'duration',
+        default: '7 days',
+        env: 'SESSION_DURATION'
+      }
     }
   }
 });

--- a/server/db/create_db.js
+++ b/server/db/create_db.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+// TODO extract schema into, you know, a schema file
+// TODO figure out migrations story - mysql-patcher? node-migrate? 
+
+var mysql = require('mysql');
+var config = require('../config');
+var log = require('../logger')('server.db');
+
+// TODO use connection pooling
+var conn = mysql.createConnection({
+  host: config.get('db.mysql.host'),
+  user: config.get('db.mysql.user'),
+  password: config.get('db.mysql.password')
+});
+
+function createDatabase(cb) {
+  var dropDatabaseQuery = 'DROP DATABASE IF EXISTS chronicle';
+  var createDatabaseQuery = 'CREATE DATABASE IF NOT EXISTS chronicle ' +
+    'CHARACTER SET utf8 COLLATE utf8_unicode_ci';
+  var useDatabaseQuery = 'USE chronicle';
+  var createTableQuery = 'CREATE TABLE IF NOT EXISTS users (' +
+    'fxa_id BINARY(16) NOT NULL PRIMARY KEY,' +
+    'email VARCHAR(256) NOT NULL,' +
+    'oauth_token VARCHAR(256),' +
+    'createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,' +
+    'updatedAt TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,' +
+    'INDEX (email)' +
+    ') ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;';
+
+  conn.connect(function (err) {
+    if (err) {
+      log.warn('error connecting to mysql: ' + err);
+      return cb(err);
+    }
+    log.info('connected to mysql as id ' + conn.threadId);
+    
+    // TODO use promises for prettier chaining
+    log.info('dropping any existing database');
+    conn.query(dropDatabaseQuery, function (err) {
+      if (err) {
+        log.warn('error dropping database: ' + err);
+        return cb(err);
+      }
+      log.info('old database dropped.');
+      log.info('creating chronicle database');
+      conn.query(createDatabaseQuery, function (err) {
+        if (err) {
+          log.warn('error creating database: ' + err);
+          return cb(err);
+        }
+        log.info('database successfully created');
+        conn.query(useDatabaseQuery, function (err) {
+          if (err) {
+            log.warn('error using database: ' + err);
+            return cb(err);
+          }
+          log.info('now using database');
+
+          log.info('creating user table');
+          conn.query(createTableQuery, function (err) {
+            if (err) {
+              log.warn('error creating user table: ' + err);
+              return cb(err);
+            }
+            log.info('user table successfully created');
+            cb();
+          });
+        });
+      });
+    });
+  });
+}
+
+createDatabase(function(err) {
+  if (err) {
+    log.warn('something went wrong: ' + err);
+  } else {
+    log.info('database created, exiting');
+  }
+});

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var mysql = require('mysql');
+var config = require('../config');
+var buf = require('buf').hex;
+var log = require('../logger')('server.db');
+
+var pool = mysql.createPool({
+  connectionLimit: config.get('db.mysql.connectionLimit'),
+  host: config.get('db.mysql.host'),
+  user: config.get('db.mysql.user'),
+  password: config.get('db.mysql.password'),
+  database: config.get('db.mysql.database')
+});
+
+function _getConn(cb) {
+  pool.getConnection(function(err, conn) {
+    if (err) {
+      log.warn('error getting connection from pool: ' + err);
+      return cb(err);
+    }
+    cb(null, conn);
+  });
+}
+
+// DB API uses callbacks for the moment; TODO return promises?
+module.exports = {
+  createUser: function(fxaId, email, oauthToken, cb) {
+    var query = 'INSERT INTO users (fxa_id, email, oauth_token) ' + 
+                'VALUES (?, ?, ?)' +
+                'ON DUPLICATE KEY UPDATE ' +
+                'fxa_id = VALUES(fxa_id), ' +
+                'email = VALUES(email), ' +
+                'oauth_token = VALUES(oauth_token)';
+    _getConn(function(err, conn) {
+      // TODO do we even want to handle pool connection errors here?
+      if (err) {
+        return cb(err);
+      }
+      conn.query(query, [buf(fxaId), email, oauthToken], function(err) {
+        if (err) {
+          log.warn('error saving user: ' + err);
+          // TODO send the item to a retry queue?
+        }
+        conn.release();
+        cb(err);
+      });
+    });
+  },
+  getUserById: function(fxaId, cb) {
+    var query = 'SELECT email, oauth_token FROM users WHERE fxa_id = ?';
+    _getConn(function(err, conn) {
+      // TODO handle conn err?
+      conn.query(query, buf(fxaId), function(err, result) {
+        if (err) {
+          log.warn('error retrieving user: ' + err);
+        }
+        conn.release();
+
+        cb(err, result);
+      });
+    });
+  }
+};
+
+// TODO attach the pool to the hapi server
+// TODO on hapi shutdown, close the pool

--- a/server/index.js
+++ b/server/index.js
@@ -5,22 +5,64 @@
 'use strict';
 
 var Hapi = require('hapi');
-var server = new Hapi.Server();
-var config = require('./config').root();
+var config = require('./config');
+var log = require('./logger')('server.index');
+var routes = require('./routes');
+
+// log extra error info if we're developing locally
+var serverConfig = (config.get('env') === 'local' ? {debug: {request: ['error']}} : {});
+  
+var server = new Hapi.Server(serverConfig);
 server.connection({
-  host: config.server.host,
-  port: config.server.port
+  host: config.get('server.host'),
+  port: config.get('server.port')
 });
-server.route({
-  method: 'GET',
-  path: '/{param*}',
-  handler: {
-    directory: {
-      path: config.server.staticPath,
-      listing: true
-    }
+
+server.register([require('hapi-auth-cookie'), require('bell')], function (err) {
+  if (err) {
+    log.warn('failed to load plugin: ' + err);
+    throw err; // TODO: should we use AppError instead?
   }
-});
-server.start(function () {
-  console.log('chronicle server running on port ' + config.server.port);
+
+  // hapi-auth-cookie init
+  // TODO: when we really have to, move this crap into a config file
+  server.auth.strategy('session', 'cookie', {
+    password: config.get('server.session.password'),
+    cookie: 'sid-chronicle', // TODO what should this be? add to config
+    redirectTo: '/',
+    isSecure: config.get('server.session.isSecure'),
+    ttl: config.get('server.session.duration')
+  });
+
+  // bell init
+  server.auth.strategy('oauth', 'bell', {
+    provider: {
+      protocol: config.get('server.oauth.protocol'),
+      auth: config.get('server.oauth.authEndpoint'),
+      token: config.get('server.oauth.tokenEndpoint'),
+      version: config.get('server.oauth.version'),
+      scope: config.get('server.oauth.scope'),
+      profile: function (credentials, params, get, profileCb) {
+        log.info('inside the oauth-bell profile callback!');
+        // TODO here's a guess at what to do in here, bell provides no example:
+        // 1. grab params.token, send it to the profile endpoint
+        // 2. put the profile response into the credentials object, then send it to DB
+      }
+    },
+    password: config.get('server.session.password'),
+    clientId: config.get('server.oauth.clientId'), 
+    clientSecret: config.get('server.oauth.clientSecret'),
+    isSecure: config.get('server.session.isSecure')
+  });
+
+  server.route(routes);
+  // TODO manage SIGTERM and friends
+  server.start(function (err) {
+    if (err) {
+      log.warn('server failed to start: ' + err);
+      throw err; // TODO: should we fail to start in some other way? AppError?
+    }
+    log.info('chronicle server running on ' + config.get('server.host') +
+              ':' + config.get('server.port'));
+  });
 });

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var mozlog = require('mozlog');
+var config = require('./config');
+
+// TODO we shouldn't need copypasta when we are composing 2 log libraries already :-\
+mozlog.config(config.get('server.log'));
+var root = mozlog(config.app);
+if (root.isEnabledFor('debug')) {
+  root.warn('\t*** CAREFUL! Louder logs (less than INFO)' +
+  ' may include SECRETS! ***');
+}
+module.exports = mozlog;

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+// TODO use reverse proxy instead of making outgoing requests directly
+//      from the webheads :-P
+var wreck = require('wreck');
+var path = require('path');
+
+var log = require('./logger')('server.routes');
+var config = require('./config');
+var db = require('./db/db');
+
+module.exports = [{
+  method: 'GET',
+  path: '/',
+  config: {
+    auth: {
+      strategy: 'session',
+      mode: 'try'
+    },
+    plugins: { 'hapi-auth-cookie': { redirectTo: false } },
+    handler: function (request, reply) {
+      var page = request.auth.isAuthenticated ? 'app.html' : 'index.html';
+      // TODO we should set a session cookie here that's visible to the client: #45
+      reply.file(path.join(__dirname, '..', config.get('server.staticPath'), page));
+    }
+  }
+}, {
+  method: 'GET',
+  path: '/auth/logout',
+  handler: function (request, reply) {
+    request.auth.session.clear();
+    return reply.redirect('/');
+  }
+}, {
+  method: 'GET',
+  path: '/auth/complete',
+  config: {
+    auth: {
+      strategy: 'oauth',
+      mode: 'try'
+    },
+    handler: function (request, reply) {
+      // at this point, the oauth dance is complete, we have a code but not a token.
+      // we need to swap the code for the token,
+      // then we need to ask the profile server for the user's profile,
+      // then we need to save the session.
+      // TODO: maybe we want this to live inside the server.auth.strategy call for bell?
+      log.info('auth/complete invoked');
+      // HUGE TODO: verify the session cookie matches the 'state' nonce in the query
+      var tokenPayload = {
+        client_id: config.get('server.oauth.clientId'),
+        client_secret: config.get('server.oauth.clientSecret'),
+        code: request.query.code
+      };
+      // 1. swap code for token
+      wreck.post(config.get('server.oauth.tokenEndpoint'),
+        { payload: JSON.stringify(tokenPayload) },
+        function(err, res, payload) {
+          if (err) {
+            log.info('token server error: ' + err);
+            // TODO something went wrong, try again? throw AppError?
+            return reply.redirect('/');
+          }
+          if (!payload) {
+            log.info('token server returned empty response');
+            return reply.redirect('/');
+          }
+          // TODO: can Joi ensure JSON.parse doesn't throw? #43
+          var pay = JSON.parse(payload);
+          var accessToken = pay && pay['access_token'];
+          log.debug('token server response: ' + payload);
+          log.debug('token server response http code: ' + res.statusCode);
+          if (!accessToken) {
+            log.info('no access token found in token server response');
+            return reply.redirect('/');
+          }
+          // 2. use the token to obtain profile data
+          wreck.get(config.get('server.oauth.profileEndpoint'),
+            { headers: {'authorization': 'Bearer ' + accessToken}},
+            function(err, res, payload) {
+              if (err) {
+                log.info('profile server error: ' + err);
+                return reply.redirect('/');
+              }
+              if (!payload) {
+                log.info('profile server returned empty response');
+                return reply.redirect('/');
+              }
+              log.info('profile server response: ' + payload);
+              // TODO: can Joi ensure JSON.parse doesn't throw? #43
+              var pay = JSON.parse(payload);
+              db.createUser(pay.uid, pay.email, accessToken, function(err) {
+                if (err) {
+                  log.info('user creation failed: ' + err);
+                  return reply.redirect('/');
+                }
+                request.auth.session.set({fxaId: payload.uid});
+                reply.redirect('/');
+              });
+            }
+          );
+        }
+      );
+    }
+  }
+}, {
+  // static routes using dist/, yay grunt
+  method: 'GET',
+  path: '/dist/{param*}',
+  handler: {
+    directory: {
+      path: path.join(__dirname, '..', config.get('server.staticPath')),
+      listing: config.get('server.staticDirListing')
+    }
+  }
+}];


### PR DESCRIPTION
Fixes #40, almost-kinda-fixes #24.

Changes of note:
- I'm able to do the complete oauth-driven login flow locally \o/
- Remove jscs rule requiring a space after `function`
- Serve static bits from `/dist`, not `/app`
- Add mozlog logging: heka compatible in prod, yet readable for local dev

Particularly ugly/dangerous TODOs:
- Added DB creation and DB client, (barely) functional yet so ugly
- Make outgoing HTTP requests from inside the route handler: reverse proxy
  needed
- Not yet using a nonce to avoid replay attacks, because hapi sessions
  are so &#$%! unnecessarily complicated

---

r? @pdehaan && @seanmonstar && @nchapman 

I've got a super super hacky (yet working) front-end in my [issue-24-WIP](https://github.com/6a68/chronicle/tree/issue-24-WIP) branch; next I'll try to get a client-side commit together that works well enough with the code already in the repo.
