### PR TITLE
Streamlined css flow

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,8 +6,7 @@
     <title>Chronicle</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
-    <link rel="stylesheet" href="assets/bower_components/normalize-css/normalize.css">
-    <link rel="stylesheet" href="assets/styles/main.css">
+    <link rel="stylesheet" href="assets/styles/compiled.css">
   </head>
   <body class="l-flexbody">
     <div id="top-bar">

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -1,3 +1,4 @@
+@import '../bower_components/normalize-scss/normalize';
 @import url(http://fonts.googleapis.com/css?family=Fira+Sans:400,700,400italic,700italic);
 
 *,

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "backbone": "~1.1.2",
     "jquery": "~2.1.1",
-    "normalize-css": "~3.0.2",
+    "normalize-scss": "~3.0.2",
     "requirejs-mustache": "*",
     "requirejs-text": "~2.0.12",
     "requirejs": "~2.1.15",

--- a/grunttasks/autoprefixer.js
+++ b/grunttasks/autoprefixer.js
@@ -7,8 +7,11 @@ module.exports = function (grunt) {
 
   grunt.config('autoprefixer', {
     dist: {
-      src: 'app/styles/main.css',
-      dest: 'app/styles/main.css'
+      src: 'dist/styles/compiled.css',
+      dest: 'dist/styles/compiled.css',
+      options: {
+        map: true
+      }
     }
   });
 };

--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -13,20 +13,8 @@ module.exports = function (grunt) {
           dest: 'dist/',
           cwd: 'app/',
           src: [
-            'bower_components/**',
-            'styles/*.css',
             'index.html'
           ]
-        }
-      ]
-    },
-    css: {
-      files: [
-        {
-          expand: true,
-          dest: 'dist/',
-          cwd: 'app/',
-          src: ['styles/*.css']
         }
       ]
     }

--- a/grunttasks/css.js
+++ b/grunttasks/css.js
@@ -7,7 +7,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('css', [
     'sass',
-    'autoprefixer',
-    'copy:css'
+    'autoprefixer'
   ]);
 };

--- a/grunttasks/sass.js
+++ b/grunttasks/sass.js
@@ -7,13 +7,14 @@ module.exports = function (grunt) {
 
   grunt.config('sass', {
     options: {
-      imagePath: '/images',
-      // outputStyle: 'compressed',
-      precision: 3
+      imagePath: '/assets/images',
+      outputStyle: 'compressed',
+      precision: 3,
+      sourceMap: true
     },
     styles: {
       files: {
-        'app/styles/main.css': 'app/styles/main.scss'
+        'dist/styles/compiled.css': 'app/styles/main.scss'
       }
     }
   });


### PR DESCRIPTION
Source maps seem to be mostly working for css. I'm not sure what the exact behavior is expected to be. `main.css` file is no longer created in `app` and is instead created directly in `dist`. I made the switch to `normalize-scss` and am importing that in `_base.scss` so we no longer have to copy over `bower_components`.

Fixes #56.

_This should be merged after #55._

@pdehaan r?
