### PR TITLE
chore(build): Improved performance of watch and build tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To fetch dependencies and get cooking:
 | Name | Description |
 |------|-------------|
 | `autoprefixer` | Adds vendor prefixes to CSS files based on <http://caniuse.com> statistics.
-| `build` | Alias for "lint", "clean:dist", "copy:dist", "css" tasks.
+| `build` | Build front-end assets and copy them to dist.
 | `changelog` | Generate a changelog from git metadata.
 | `clean` | Deletes files and folders.
 | `contributors` | Generates a list of contributors from your project's git history.

--- a/grunttasks/build.js
+++ b/grunttasks/build.js
@@ -5,11 +5,17 @@
 module.exports = function (grunt) {
   'use strict';
 
-  grunt.registerTask('build', [
-    'lint',
-    'clean',
-    'copy',
-    'requirejs',
-    'css'
-  ]);
+  grunt.registerTask('build', 'Build front-end assets and copy them to dist', function (target) {
+    if (!target) {
+      target = 'development';
+    }
+
+    grunt.task.run([
+      'lint',
+      'clean',
+      'copy',
+      'requirejs:' + target,
+      'css'
+    ]);
+  });
 };

--- a/grunttasks/requirejs.js
+++ b/grunttasks/requirejs.js
@@ -2,29 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var _ = require('underscore');
+
 module.exports = function (grunt) {
   'use strict';
 
+  var DEFAULT_OPTIONS = {
+    almond: true,
+    baseUrl: 'app/scripts',
+    generateSourceMaps: true,
+    mainConfigFile: 'app/scripts/main.js',
+    name: 'main',
+    optimize: 'none',
+    out: 'dist/scripts/compiled.js',
+    preserveLicenseComments: false,
+    removeCombined: true,
+    replaceRequireScript: [{
+      files: ['dist/index.html'],
+      module: 'main',
+      modulePath: '/assets/scripts/compiled'
+    }],
+    stubModules: ['text', 'stache'],
+    useStrict: true
+  };
+
   grunt.config('requirejs', {
-    dist: {
-      options: {
-        almond: true,
-        baseUrl: 'app/scripts',
-        generateSourceMaps: true,
-        mainConfigFile: 'app/scripts/main.js',
-        name: 'main',
-        optimize: 'uglify2',
-        out: 'dist/scripts/compiled.js',
-        preserveLicenseComments: false,
-        removeCombined: true,
-        replaceRequireScript: [{
-          files: ['dist/index.html'],
-          module: 'main',
-          modulePath: '/assets/scripts/compiled'
-        }],
-        stubModules: ['text', 'stache'],
-        useStrict: true
-      }
+    development: {
+      options: DEFAULT_OPTIONS
+    },
+    production: {
+      options: _.extend({}, DEFAULT_OPTIONS, { optimize: 'uglify2' })
     }
   });
 };

--- a/grunttasks/serve.js
+++ b/grunttasks/serve.js
@@ -6,8 +6,8 @@ module.exports = function (grunt) {
   'use strict';
 
   grunt.registerTask('serve', [
+    'build:development',
     'hapi',
-    'build',
     'watch'
   ]);
 };

--- a/grunttasks/watch.js
+++ b/grunttasks/watch.js
@@ -8,14 +8,10 @@ module.exports = function (grunt) {
   grunt.config('watch', {
     config: {
       files: ['Gruntfile.js', 'grunttasks/*'],
-      tasks: ['build'],
+      tasks: ['build:development'],
       options: {
         reload: true
       }
-    },
-    build: {
-      files: ['app/**/*'],
-      tasks: ['build']
     },
     hapi: {
       files: ['server/**/*'],
@@ -24,12 +20,24 @@ module.exports = function (grunt) {
         spawn: false
       }
     },
+    html: {
+      files: ['app/*.html'],
+      tasks: ['copy']
+    },
     livereload: {
       // Watch for file changes in dist to trigger livereload
       files: ['dist/**/*'],
       options: {
         livereload: true
       }
+    },
+    scripts: {
+      files: ['app/scripts/**/*'],
+      tasks: ['lint', 'requirejs:development']
+    },
+    styles: {
+      files: ['app/styles/**/*'],
+      tasks: ['css']
     }
   });
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -867,7 +867,7 @@
     },
     "grunt-hapi": {
       "version": "0.8.1",
-      "from": "grunt-hapi@*",
+      "from": "https://registry.npmjs.org/grunt-hapi/-/grunt-hapi-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-hapi/-/grunt-hapi-0.8.1.tgz"
     },
     "grunt-jscs": {
@@ -1997,58 +1997,58 @@
     },
     "grunt-todo": {
       "version": "0.4.0",
-      "from": "grunt-todo@0.4.0",
+      "from": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -2733,6 +2733,11 @@
       "version": "1.0.7",
       "from": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz"
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "from": "underscore@*",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "uuid": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "load-grunt-tasks": "1.0.0",
     "mozlog": "1.0.0",
     "mysql": "2.5.3",
+    "underscore": "1.7.0",
     "uuid": "2.0.1",
     "wreck": "5.1.0"
   },
@@ -52,7 +53,7 @@
     "authors": "grunt contributors",
     "lint": "grunt lint",
     "outdated": "npm outdated --depth 0",
-    "postinstall": "bower update --config.interactive=false -s && grunt build",
+    "postinstall": "bower update --config.interactive=false -s",
     "shrinkwrap": "npm shrinkwrap --dev && npm run validate",
     "start": "grunt serve",
     "test": "echo \"Error: no test specified\"",


### PR DESCRIPTION
Watch is now configured to call specific tasks when certain files change. This will be more work to maintain but the performance should be much better as the project grows. The `requirejs` task now has `development` and `production` targets to improve performance when using `grunt serve`.

@6a68 @pdehaan r?