### PR TITLE
chore(build): Updating a couple dependencies and removing jshint devDep

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,42 +4,42 @@
   "dependencies": {
     "bell": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/bell/-/bell-2.0.0.tgz",
+      "from": "bell@2.0.0",
       "resolved": "https://registry.npmjs.org/bell/-/bell-2.0.0.tgz",
       "dependencies": {
         "boom": {
           "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.x.x",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "hoek": {
-          "version": "2.10.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
+          "version": "2.11.0",
+          "from": "hoek@2.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "joi": {
-          "version": "5.0.2",
-          "from": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
+          "version": "5.1.0",
+          "from": "joi@5.x.x",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
           "dependencies": {
             "topo": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+              "from": "topo@1.x.x",
               "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
             },
             "isemail": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "from": "isemail@1.x.x",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             },
             "moment": {
               "version": "2.8.4",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+              "from": "moment@2.x.x",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
             }
           }
@@ -48,52 +48,52 @@
     },
     "buf": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz",
+      "from": "buf@0.1.0",
       "resolved": "https://registry.npmjs.org/buf/-/buf-0.1.0.tgz"
     },
     "convict": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
+      "from": "convict@0.6.0",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+          "from": "cjson@0.3.0",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+              "from": "jsonlint@1.6.0",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                  "from": "nomnom@>= 1.5.x",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "from": "underscore@~1.6.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                      "from": "chalk@~0.4.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "from": "has-color@~0.1.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "from": "ansi-styles@~1.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                          "from": "strip-ansi@~0.1.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -102,7 +102,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "from": "JSV@>= 4.0.x",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -111,96 +111,96 @@
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "moment": {
           "version": "2.8.3",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz",
+          "from": "moment@2.8.3",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.22.1",
-          "from": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz",
+          "from": "validator@3.22.1",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz"
         }
       }
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@~0.4.2",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@~1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@~0.4.13",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~3.2.9",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -209,144 +209,139 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@~1.2.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@~0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@~0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@~2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.8",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.8.tgz",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@~2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
-                "underscore": {
-                  "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-                },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@~0.1.1",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@~0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "from": "grunt-legacy-log@~0.1.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@~2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -354,40 +349,40 @@
       }
     },
     "grunt-autoprefixer": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.0.0.tgz",
+      "version": "2.1.0",
+      "from": "grunt-autoprefixer@2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.1.0.tgz",
       "dependencies": {
         "autoprefixer-core": {
           "version": "4.0.2",
-          "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-4.0.2.tgz",
+          "from": "autoprefixer-core@^4.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-4.0.2.tgz",
           "dependencies": {
             "caniuse-db": {
-              "version": "1.0.30000036",
-              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000036.tgz",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000036.tgz"
+              "version": "1.0.30000043",
+              "from": "caniuse-db@^1.0.30000030",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000043.tgz"
             },
             "postcss": {
               "version": "3.0.7",
-              "from": "https://registry.npmjs.org/postcss/-/postcss-3.0.7.tgz",
+              "from": "postcss@~3.0.6",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-3.0.7.tgz",
               "dependencies": {
                 "source-map": {
-                  "version": "0.1.41",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                  "version": "0.1.42",
+                  "from": "source-map@~0.1.40",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.42.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "js-base64": {
                   "version": "2.1.5",
-                  "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz",
+                  "from": "js-base64@~2.1.5",
                   "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz"
                 }
               }
@@ -395,52 +390,52 @@
           }
         },
         "diff": {
-          "version": "1.0.8",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
+          "version": "1.2.1",
+          "from": "diff@~1.2.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.2.1.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -449,63 +444,63 @@
     },
     "grunt-contrib-clean": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
+      "from": "grunt-contrib-clean@0.6.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@~2.2.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "grunt-contrib-copy": {
       "version": "0.7.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.7.0.tgz",
+      "from": "grunt-contrib-copy@0.7.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.7.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -514,66 +509,212 @@
     },
     "grunt-contrib-jshint": {
       "version": "0.10.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "from": "grunt-contrib-jshint@0.10.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
+        "jshint": {
+          "version": "2.5.11",
+          "from": "jshint@~2.5.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+          "dependencies": {
+            "cli": {
+              "version": "0.6.5",
+              "from": "cli@0.6.x",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@~ 3.2.1",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@1.1.x",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@^0.1.4",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@0.1.x",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            },
+            "htmlparser2": {
+              "version": "3.8.2",
+              "from": "htmlparser2@3.8.x",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0",
+                  "from": "domhandler@2.3",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.0",
+                  "from": "domutils@1.5",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                },
+                "domelementtype": {
+                  "version": "1.1.3",
+                  "from": "domelementtype@1",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@1.1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "from": "entities@1.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@1.0.x",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "shelljs@0.3.x",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.2",
+              "from": "strip-json-comments@1.0.x",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+            },
+            "underscore": {
+              "version": "1.6.0",
+              "from": "underscore@1.6.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+            }
+          }
+        },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
     },
     "grunt-contrib-watch": {
       "version": "0.6.1",
-      "from": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "from": "grunt-contrib-watch@0.6.1",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
       "dependencies": {
         "gaze": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "from": "gaze@~0.5.1",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "from": "globule@~0.1.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz",
+                  "from": "lodash@~1.0.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "from": "glob@~3.1.21",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                      "from": "graceful-fs@~1.2.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                      "from": "inherits@1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@~0.2.11",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -584,32 +725,32 @@
         },
         "tiny-lr-fork": {
           "version": "0.0.5",
-          "from": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+          "from": "tiny-lr-fork@0.0.5",
           "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
           "dependencies": {
             "qs": {
               "version": "0.5.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+              "from": "qs@~0.5.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+              "from": "faye-websocket@~0.4.3",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
             "noptify": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+              "from": "noptify@~0.0.3",
               "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                  "from": "nopt@~2.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
@@ -618,155 +759,155 @@
             },
             "debug": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "from": "debug@~0.7.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
     },
     "grunt-conventional-changelog": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.1.0.tgz",
+      "from": "grunt-conventional-changelog@1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.1.0.tgz",
       "dependencies": {
         "conventional-changelog": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
+          "from": "conventional-changelog@0.0.6",
           "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
           "dependencies": {
             "lodash.assign": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+              "from": "lodash.assign@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
               "dependencies": {
                 "lodash._basecreatecallback": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                  "from": "lodash._basecreatecallback@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
                   "dependencies": {
                     "lodash.bind": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                      "from": "lodash.bind@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
                       "dependencies": {
                         "lodash._createwrapper": {
                           "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                          "from": "lodash._createwrapper@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
                           "dependencies": {
                             "lodash._basebind": {
                               "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                              "from": "lodash._basebind@~2.4.1",
                               "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
                               "dependencies": {
                                 "lodash._basecreate": {
                                   "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "from": "lodash._basecreate@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
                                   "dependencies": {
                                     "lodash._isnative": {
                                       "version": "2.4.1",
-                                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                      "from": "lodash._isnative@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                                     },
                                     "lodash.noop": {
                                       "version": "2.4.1",
-                                      "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "from": "lodash.noop@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                                     }
                                   }
                                 },
                                 "lodash.isobject": {
                                   "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                  "from": "lodash.isobject@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                                 }
                               }
                             },
                             "lodash._basecreatewrapper": {
                               "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                              "from": "lodash._basecreatewrapper@~2.4.1",
                               "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
                               "dependencies": {
                                 "lodash._basecreate": {
                                   "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "from": "lodash._basecreate@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
                                   "dependencies": {
                                     "lodash._isnative": {
                                       "version": "2.4.1",
-                                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                      "from": "lodash._isnative@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                                     },
                                     "lodash.noop": {
                                       "version": "2.4.1",
-                                      "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "from": "lodash.noop@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                                     }
                                   }
                                 },
                                 "lodash.isobject": {
                                   "version": "2.4.1",
-                                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                  "from": "lodash.isobject@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                                 }
                               }
                             },
                             "lodash.isfunction": {
                               "version": "2.4.1",
-                              "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                              "from": "lodash.isfunction@~2.4.1",
                               "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                             }
                           }
                         },
                         "lodash._slice": {
                           "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                          "from": "lodash._slice@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash.identity": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                      "from": "lodash.identity@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
                     },
                     "lodash._setbinddata": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                      "from": "lodash._setbinddata@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
                       "dependencies": {
                         "lodash._isnative": {
                           "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "from": "lodash._isnative@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                         },
                         "lodash.noop": {
                           "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                          "from": "lodash.noop@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash.support": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                      "from": "lodash.support@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
                       "dependencies": {
                         "lodash._isnative": {
                           "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "from": "lodash._isnative@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                         }
                       }
@@ -775,71 +916,71 @@
                 },
                 "lodash.keys": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "from": "lodash.keys@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "from": "lodash._isnative@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
                     "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "from": "lodash.isobject@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                     },
                     "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "from": "lodash._shimkeys@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash._objecttypes": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                  "from": "lodash._objecttypes@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                 }
               }
             },
             "event-stream": {
               "version": "3.1.7",
-              "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+              "from": "event-stream@~3.1.0",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
+                  "from": "through@~2.3.1",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                  "from": "duplexer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+                  "from": "from@~0",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+                  "from": "map-stream@~0.1.0",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
                   "version": "0.0.11",
-                  "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+                  "from": "pause-stream@0.0.11",
                   "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
                 },
                 "split": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+                  "from": "split@0.2",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                  "from": "stream-combiner@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
@@ -850,89 +991,94 @@
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
+      "from": "grunt-copyright@0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
     },
     "grunt-git-contributors": {
       "version": "0.1.5",
-      "from": "https://registry.npmjs.org/grunt-git-contributors/-/grunt-git-contributors-0.1.5.tgz",
+      "from": "grunt-git-contributors@0.1.5",
       "resolved": "https://registry.npmjs.org/grunt-git-contributors/-/grunt-git-contributors-0.1.5.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz",
+          "from": "lodash@~2.2.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
         }
       }
     },
     "grunt-hapi": {
       "version": "0.8.1",
-      "from": "https://registry.npmjs.org/grunt-hapi/-/grunt-hapi-0.8.1.tgz",
+      "from": "grunt-hapi@0.8.1",
       "resolved": "https://registry.npmjs.org/grunt-hapi/-/grunt-hapi-0.8.1.tgz"
     },
     "grunt-jscs": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.0.0.tgz",
+      "version": "1.1.0",
+      "from": "grunt-jscs@1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.1.0.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
-          "version": "1.8.1",
-          "from": "https://registry.npmjs.org/jscs/-/jscs-1.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.8.1.tgz",
+          "version": "1.9.0",
+          "from": "jscs@~1.9.0",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.9.0.tgz",
           "dependencies": {
             "colors": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "from": "colors@~1.0.3",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "commander": {
               "version": "2.5.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
+              "from": "commander@~2.5.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
             },
             "esprima": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+              "from": "esprima@~1.2.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
             },
             "esprima-harmony-jscs": {
               "version": "1.1.0-dev-harmony",
-              "from": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz",
+              "from": "esprima-harmony-jscs@1.1.0-dev-harmony",
               "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz"
+            },
+            "estraverse": {
+              "version": "1.8.0",
+              "from": "estraverse@~1.8.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.8.0.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@~0.1.2",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "4.0.6",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+              "from": "glob@~4.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.5",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
+                  "from": "graceful-fs@^3.0.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -941,81 +1087,81 @@
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "from": "minimatch@~1.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+              "from": "strip-json-comments@~1.0.1",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
+              "from": "vow-fs@~0.3.1",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
+                  "from": "node-uuid@^1.4.2",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz",
+                  "from": "vow-queue@^0.4.1",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
                 },
                 "glob": {
                   "version": "4.3.2",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.2.tgz",
+                  "from": "glob@^4.3.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.2.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                      "from": "minimatch@^2.0.1",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "from": "brace-expansion@^1.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                              "from": "balanced-match@^0.2.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -1024,12 +1170,12 @@
                     },
                     "once": {
                       "version": "1.3.1",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -1040,73 +1186,83 @@
             },
             "xmlbuilder": {
               "version": "2.4.5",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.5.tgz",
+              "from": "xmlbuilder@~2.4.0",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.5.tgz",
               "dependencies": {
                 "lodash-node": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+                  "from": "lodash-node@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+              "from": "supports-color@~1.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
+            },
+            "unicode-6.3.0": {
+              "version": "0.1.5",
+              "from": "unicode-6.3.0@~0.1.5",
+              "resolved": "https://registry.npmjs.org/unicode-6.3.0/-/unicode-6.3.0-0.1.5.tgz"
+            },
+            "regenerate": {
+              "version": "1.0.1",
+              "from": "regenerate@~1.0.1",
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.0.1.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "vow": {
           "version": "0.4.7",
-          "from": "https://registry.npmjs.org/vow/-/vow-0.4.7.tgz",
+          "from": "vow@~0.4.1",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.7.tgz"
         }
       }
     },
     "grunt-jsonlint": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
+      "from": "grunt-jsonlint@1.0.4",
       "resolved": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
       "dependencies": {
         "jsonlint": {
           "version": "1.6.0",
-          "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+          "from": "jsonlint@1.6.0",
           "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
           "dependencies": {
             "nomnom": {
               "version": "1.8.1",
-              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+              "from": "nomnom@>= 1.5.x",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "from": "underscore@~1.6.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "from": "chalk@~0.4.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "from": "has-color@~0.1.0",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                      "from": "ansi-styles@~1.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                      "from": "strip-ansi@~0.1.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -1115,7 +1271,7 @@
             },
             "JSV": {
               "version": "4.0.2",
-              "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+              "from": "JSV@>= 4.0.x",
               "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
             }
           }
@@ -1124,32 +1280,32 @@
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "from": "cli-color@^0.2.3",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+              "from": "es5-ext@~0.9.2",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "from": "memoizee@~0.2.5",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+                  "from": "event-emitter@~0.2.2",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+                  "from": "next-tick@0.1.x",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -1158,42 +1314,242 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@^0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "grunt": {
+          "version": "0.4.5",
+          "from": "grunt@~0.4.2",
+          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "from": "async@~0.1.22",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+            },
+            "coffee-script": {
+              "version": "1.3.3",
+              "from": "coffee-script@~1.3.3",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.2-1.2.3",
+              "from": "dateformat@1.0.2-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+            },
+            "eventemitter2": {
+              "version": "0.4.14",
+              "from": "eventemitter2@~0.4.13",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+            },
+            "findup-sync": {
+              "version": "0.1.3",
+              "from": "findup-sync@~0.1.2",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@~3.2.9",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@~3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@~1.2.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "from": "hooker@~0.2.3",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+            },
+            "iconv-lite": {
+              "version": "0.2.11",
+              "from": "iconv-lite@~0.2.11",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@~0.2.12",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "1.0.10",
+              "from": "nopt@~1.0.10",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@1",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "lodash": {
+              "version": "0.9.2",
+              "from": "lodash@~0.9.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+            },
+            "underscore.string": {
+              "version": "2.2.1",
+              "from": "underscore.string@~2.2.1",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+            },
+            "which": {
+              "version": "1.0.8",
+              "from": "which@~1.0.5",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
+            },
+            "js-yaml": {
+              "version": "2.0.5",
+              "from": "js-yaml@~2.0.5",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.16",
+                  "from": "argparse@~ 0.1.11",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+                  "dependencies": {
+                    "underscore.string": {
+                      "version": "2.4.0",
+                      "from": "underscore.string@~2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@~ 1.0.2",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@~0.1.1",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            },
+            "getobject": {
+              "version": "0.1.0",
+              "from": "getobject@~0.1.0",
+              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+            },
+            "grunt-legacy-util": {
+              "version": "0.2.0",
+              "from": "grunt-legacy-util@~0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+            },
+            "grunt-legacy-log": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log@~0.1.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            }
+          }
         },
         "request": {
           "version": "2.51.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+          "from": "request@^2.34.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.3",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+              "from": "bl@~0.9.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@~1.0.26",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1202,33 +1558,33 @@
             },
             "caseless": {
               "version": "0.8.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+              "from": "caseless@~0.8.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "from": "forever-agent@~0.5.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "from": "form-data@~0.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                  "from": "async@~0.9.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
+                  "version": "2.0.7",
+                  "from": "mime-types@~2.0.3",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.3.1",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
+                      "version": "1.5.0",
+                      "from": "mime-db@~1.5.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
                     }
                   }
                 }
@@ -1236,113 +1592,113 @@
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+              "from": "json-stringify-safe@~5.0.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+              "from": "mime-types@~1.0.1",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
+              "from": "node-uuid@~1.4.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "qs": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "from": "qs@~2.3.1",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@~0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "from": "tough-cookie@>=0.12.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "from": "punycode@>=0.2.0",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
             },
             "http-signature": {
-              "version": "0.10.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+              "version": "0.10.1",
+              "from": "http-signature@~0.10.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                  "version": "0.1.5",
+                  "from": "assert-plus@^0.1.5",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
-                  "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+              "from": "oauth-sign@~0.5.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
             },
             "hawk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "from": "hawk@1.1.1",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                  "from": "hoek@0.9.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                  "from": "boom@0.4.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                  "from": "cryptiles@0.2.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                  "from": "sntp@0.2.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@~0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@~0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "from": "combined-stream@~0.0.5",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "from": "delayed-stream@0.0.5",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
@@ -1351,69 +1707,69 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "grunt-requirejs": {
       "version": "0.4.2",
-      "from": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
+      "from": "grunt-requirejs@0.4.2",
       "resolved": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
       "dependencies": {
         "requirejs": {
           "version": "2.1.15",
-          "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.15.tgz",
+          "from": "requirejs@2.1.x",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.15.tgz"
         },
         "cheerio": {
           "version": "0.13.1",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
+          "from": "cheerio@0.13.x",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.4.0",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
+              "from": "htmlparser2@~3.4.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+                  "from": "domhandler@2.2",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz",
+                  "from": "domutils@1.3",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@1.1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1422,32 +1778,32 @@
             },
             "underscore": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+              "from": "underscore@~1.5",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+              "from": "entities@0.x",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "from": "CSSselect@~0.4.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                  "from": "CSSwhat@0.4",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "from": "domutils@1.4",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "from": "domelementtype@1",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
@@ -1458,163 +1814,163 @@
         },
         "almond": {
           "version": "0.2.9",
-          "from": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz",
+          "from": "almond@0.2.x",
           "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
         },
         "gzip-js": {
           "version": "0.3.2",
-          "from": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
+          "from": "gzip-js@0.3.x",
           "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "dependencies": {
             "crc32": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
+              "from": "crc32@>= 0.2.2",
               "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
             },
             "deflate-js": {
               "version": "0.2.3",
-              "from": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
+              "from": "deflate-js@>= 0.2.2",
               "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
             }
           }
         },
         "q": {
           "version": "0.8.12",
-          "from": "https://registry.npmjs.org/q/-/q-0.8.12.tgz",
+          "from": "q@0.8.x",
           "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
         }
       }
     },
     "grunt-sass": {
       "version": "0.17.0",
-      "from": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.17.0.tgz",
+      "from": "grunt-sass@0.17.0",
       "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.17.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@~0.5",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "each-async": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.0.tgz",
+          "version": "1.1.1",
+          "from": "each-async@^1.0.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+              "from": "onetime@^1.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
-            "setimmediate": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz"
+            "set-immediate-shim": {
+              "version": "1.0.0",
+              "from": "set-immediate-shim@^1.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
             }
           }
         },
         "node-sass": {
           "version": "1.2.3",
-          "from": "https://registry.npmjs.org/node-sass/-/node-sass-1.2.3.tgz",
+          "from": "node-sass@1.2.3",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-1.2.3.tgz",
           "dependencies": {
             "cross-spawn": {
               "version": "0.2.3",
-              "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.3.tgz",
+              "from": "cross-spawn@^0.2.3",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.3.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@^2.5.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+              "from": "gaze@^0.5.1",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "from": "globule@~0.1.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz",
+                      "from": "lodash@~1.0.1",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "from": "glob@~3.1.21",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                          "from": "graceful-fs@~1.2.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                          "from": "inherits@1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "from": "minimatch@~0.2.11",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -1625,44 +1981,44 @@
             },
             "get-stdin": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+              "from": "get-stdin@^3.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
             },
             "meow": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+              "from": "meow@^2.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@^1.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
+                      "from": "camelcase@^1.0.1",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
+                      "from": "map-obj@^1.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
+                  "from": "indent-string@^1.1.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
+                      "from": "repeating@^1.1.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
+                          "from": "is-finite@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                         }
                       }
@@ -1671,107 +2027,107 @@
                 },
                 "minimist": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
+                  "from": "minimist@^1.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@^0.5.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "mocha": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
+              "from": "mocha@^2.0.1",
               "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+                  "from": "commander@2.3.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
                 },
                 "debug": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+                  "from": "debug@2.0.0",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                      "from": "ms@0.6.2",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     }
                   }
                 },
                 "diff": {
                   "version": "1.0.8",
-                  "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+                  "from": "diff@1.0.8",
                   "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+                  "from": "escape-string-regexp@1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.2.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+                  "from": "glob@3.2.3",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "from": "minimatch@~0.2.11",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                      "from": "graceful-fs@~2.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "growl": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+                  "from": "growl@1.8.1",
                   "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
                 },
                 "jade": {
                   "version": "0.26.3",
-                  "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+                  "from": "jade@0.26.3",
                   "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                      "from": "commander@0.6.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                     },
                     "mkdirp": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                      "from": "mkdirp@0.3.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                     }
                   }
@@ -1780,52 +2136,52 @@
             },
             "nan": {
               "version": "1.4.1",
-              "from": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz",
+              "from": "nan@^1.3.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
             },
             "object-assign": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+              "from": "object-assign@^1.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
             },
             "replace-ext": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "from": "replace-ext@0.0.1",
               "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "request": {
               "version": "2.51.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "from": "request@^2.48.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.3",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@~1.0.26",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -1834,33 +2190,33 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "from": "caseless@~0.8.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@~0.5.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "from": "form-data@~0.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                      "from": "async@~0.9.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     },
                     "mime-types": {
-                      "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
+                      "version": "2.0.7",
+                      "from": "mime-types@~2.0.3",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.3.1",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
+                          "version": "1.5.0",
+                          "from": "mime-db@~1.5.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
                         }
                       }
                     }
@@ -1868,113 +2224,113 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@~1.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
+                  "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "from": "qs@~2.3.1",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                      "from": "punycode@>=0.2.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
                 },
                 "http-signature": {
-                  "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                  "version": "0.10.1",
+                  "from": "http-signature@~0.10.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
-                      "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "from": "oauth-sign@~0.5.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@0.9.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@0.4.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@0.2.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@0.2.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@~0.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -1983,119 +2339,119 @@
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "from": "shelljs@^0.3.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+          "from": "object-assign@^2.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         }
       }
     },
     "grunt-todo": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
+      "from": "grunt-todo@0.4.0",
       "resolved": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@~0.5",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@~0.2",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "hapi": {
       "version": "8.0.0",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-8.0.0.tgz",
+      "from": "hapi@8.0.0",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.0.0.tgz",
       "dependencies": {
         "accept": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "from": "accept@1.0.0",
           "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
         },
         "ammo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+          "from": "ammo@1.0.0",
           "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
         },
         "boom": {
           "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.6.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "call": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+          "from": "call@2.0.1",
           "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
         },
         "catbox": {
           "version": "4.2.0",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-4.2.0.tgz",
+          "from": "catbox@4.2.0",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.2.0.tgz",
           "dependencies": {
             "joi": {
               "version": "4.9.0",
-              "from": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
+              "from": "joi@4.x.x",
               "resolved": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                  "from": "isemail@1.x.x",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+                  "from": "moment@2.x.x",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 }
               }
@@ -2104,133 +2460,133 @@
         },
         "catbox-memory": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+          "from": "catbox-memory@1.1.1",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
+          "from": "h2o2@4.0.0",
           "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz"
         },
         "heavy": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+          "from": "heavy@3.0.0",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz"
         },
         "hoek": {
           "version": "2.10.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz",
+          "from": "hoek@2.10.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
         },
         "inert": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/inert/-/inert-2.0.0.tgz",
+          "from": "inert@2.0.0",
           "resolved": "https://registry.npmjs.org/inert/-/inert-2.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
         },
         "iron": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "from": "iron@2.1.2",
           "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
         },
         "items": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "from": "items@1.1.0",
           "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
         },
         "joi": {
           "version": "5.0.2",
-          "from": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
+          "from": "joi@5.0.2",
           "resolved": "https://registry.npmjs.org/joi/-/joi-5.0.2.tgz",
           "dependencies": {
             "isemail": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "from": "isemail@1.1.1",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
             },
             "moment": {
               "version": "2.8.4",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+              "from": "moment@2.8.4",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
             }
           }
         },
         "kilt": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "from": "kilt@1.1.1",
           "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "mimos": {
           "version": "2.0.2",
-          "from": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+          "from": "mimos@2.0.2",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz",
+              "from": "mime-db@1.3.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.0.tgz"
             }
           }
         },
         "peekaboo": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+          "from": "peekaboo@1.0.0",
           "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
         },
         "qs": {
           "version": "2.3.3",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "from": "qs@2.3.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "shot": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.4.0.tgz",
+          "from": "shot@1.4.0",
           "resolved": "https://registry.npmjs.org/shot/-/shot-1.4.0.tgz"
         },
         "statehood": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
+          "from": "statehood@2.0.0",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz"
         },
         "subtext": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+          "from": "subtext@1.0.2",
           "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
           "dependencies": {
             "content": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "from": "content@1.0.1",
               "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
             },
             "pez": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "from": "pez@1.0.0",
               "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
               "dependencies": {
                 "b64": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "from": "b64@2.0.0",
                   "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                 },
                 "nigel": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "from": "nigel@1.0.1",
                   "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                   "dependencies": {
                     "vise": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "from": "vise@1.0.0",
                       "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                     }
                   }
@@ -2241,71 +2597,71 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "from": "topo@1.0.2",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
+          "from": "vision@2.0.0",
           "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz"
         },
         "wreck": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz",
+          "from": "wreck@5.0.1",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.0.1.tgz"
         }
       }
     },
     "hapi-auth-cookie": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/hapi-auth-cookie/-/hapi-auth-cookie-2.0.0.tgz",
+      "from": "hapi-auth-cookie@2.0.0",
       "resolved": "https://registry.npmjs.org/hapi-auth-cookie/-/hapi-auth-cookie-2.0.0.tgz",
       "dependencies": {
         "boom": {
           "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.x.x",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         },
         "hoek": {
-          "version": "2.10.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
+          "version": "2.11.0",
+          "from": "hoek@2.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
     },
     "jshint": {
-      "version": "2.5.10",
-      "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.10.tgz",
+      "version": "2.5.11",
+      "from": "jshint@",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.5",
-          "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+          "from": "cli@0.6.x",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@~ 3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2316,178 +2672,178 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "from": "console-browserify@1.1.x",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "from": "date-now@^0.1.4",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@0.1.x",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+          "from": "htmlparser2@3.8.x",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "from": "domhandler@2.3",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.0",
-              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
+              "from": "domutils@1.5",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
             },
             "domelementtype": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+              "from": "domelementtype@1",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@1.1",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "from": "entities@1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "from": "minimatch@1.0.x",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "from": "shelljs@0.3.x",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+          "from": "strip-json-comments@1.0.x",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "from": "underscore@1.6.x",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "jshint-stylish": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
+      "from": "jshint-stylish@1.0.0",
       "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz",
+          "from": "log-symbols@^1.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
         },
         "string-length": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+          "from": "string-length@^1.0.0",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
+              "from": "strip-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz",
+                  "from": "ansi-regex@^1.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
                 }
               }
@@ -2496,93 +2852,126 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "load-grunt-tasks": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-1.0.0.tgz",
+      "version": "2.0.0",
+      "from": "load-grunt-tasks@2.0.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-2.0.0.tgz",
       "dependencies": {
         "findup-sync": {
-          "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "version": "0.2.1",
+          "from": "findup-sync@^0.2.1",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
           "dependencies": {
             "glob": {
-              "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "version": "4.3.2",
+              "from": "glob@~4.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.2.tgz",
               "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@^1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "version": "2.0.1",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@^1.3.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 }
               }
-            },
-            "lodash": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-1.0.1.tgz",
+          "version": "2.0.0",
+          "from": "multimatch@^2.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "from": "array-differ@^1.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "from": "array-union@^1.0.1",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                  "from": "array-uniq@^1.0.1",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "version": "2.0.1",
+              "from": "minimatch@^2.0.1",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -2592,171 +2981,171 @@
     },
     "mozlog": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/mozlog/-/mozlog-1.0.0.tgz",
+      "from": "mozlog@1.0.0",
       "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-1.0.0.tgz",
       "dependencies": {
         "intel": {
           "version": "1.0.0-b6",
-          "from": "https://registry.npmjs.org/intel/-/intel-1.0.0-b6.tgz",
+          "from": "intel@1.0.0-b6",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0-b6.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "from": "chalk@~0.5.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "from": "ansi-styles@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+                  "from": "escape-string-regexp@^1.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "from": "has-ansi@^0.1.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@^0.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "from": "strip-ansi@^0.3.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@^0.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "from": "supports-color@^0.2.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+              "from": "dbug@~0.4.1",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "depd": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+              "from": "depd@~1.0.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@~0.0.9",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz",
+              "from": "strftime@~0.8.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
+              "from": "symbol@~0.2.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+              "from": "utcstring@~0.1.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "from": "merge@1.2.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "mysql": {
       "version": "2.5.3",
-      "from": "https://registry.npmjs.org/mysql/-/mysql-2.5.3.tgz",
+      "from": "mysql@2.5.3",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.5.3.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.1.tgz",
+          "from": "bignumber.js@1.4.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@~1.1.13",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@~1.0.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@~0.10.x",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "require-all": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz",
+          "from": "require-all@0.0.8",
           "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
         }
       }
     },
     "precommit-hook": {
       "version": "1.0.7",
-      "from": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz",
+      "from": "precommit-hook@1.0.7",
       "resolved": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz"
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "underscore@*",
+      "from": "underscore@1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "uuid": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "from": "uuid@2.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
     },
     "wreck": {
       "version": "5.1.0",
-      "from": "https://registry.npmjs.org/wreck/-/wreck-5.1.0.tgz",
+      "from": "wreck@5.1.0",
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.1.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.10.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.10.0.tgz"
+          "version": "2.11.0",
+          "from": "hoek@2.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "boom": {
           "version": "2.6.1",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.x.x",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "convict": "0.6.0",
     "hapi": "8.0.0",
     "hapi-auth-cookie": "2.0.0",
-    "load-grunt-tasks": "1.0.0",
     "mozlog": "1.0.0",
     "mysql": "2.5.3",
     "underscore": "1.7.0",
@@ -20,7 +19,7 @@
     "wreck": "5.1.0"
   },
   "devDependencies": {
-    "grunt-autoprefixer": "2.0.0",
+    "grunt-autoprefixer": "2.1.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-copy": "0.7.0",
     "grunt-contrib-jshint": "0.10.0",
@@ -29,14 +28,14 @@
     "grunt-copyright": "0.1.0",
     "grunt-git-contributors": "0.1.5",
     "grunt-hapi": "0.8.1",
-    "grunt-jscs": "1.0.0",
+    "grunt-jscs": "1.1.0",
     "grunt-jsonlint": "1.0.4",
     "grunt-nsp-shrinkwrap": "0.0.3",
     "grunt-requirejs": "0.4.2",
     "grunt-sass": "0.17.0",
     "grunt-todo": "0.4.0",
-    "jshint": "2.5.10",
     "jshint-stylish": "1.0.0",
+    "load-grunt-tasks": "2.0.0",
     "precommit-hook": "1.0.7"
   },
   "engines": {


### PR DESCRIPTION
Fixed a couple outdated dependencies and removed an odd "jshint" dependency (odd because that should be included via grunt-contrib-jshint anyways).

We should still have about 2 outdated modules (`mozlog` and `mysql`, both with patch level version bumps -- not that we really care right now):

```
$ npm run outdated

> mozilla-chronicle@0.1.0 outdated /Users/pdehaan/dev/github/chronicle
> npm outdated --depth 0

Package  Current  Wanted  Latest  Location
mozlog     1.0.0   1.0.0   1.0.1  mozlog
mysql      2.5.3   2.5.3   2.5.4  mysql
```