### PR TITLE
chore(git): exclude npm-shrinkwrap.json from git diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+npm-shrinkwrap.json -diff


### PR DESCRIPTION
This change will exclude npm-shrinkwrap.json from the output of `git diff` as well as `git log -p`.

Got the idea from [SO](http://stackoverflow.com/questions/1016798/excluding-files-from-git-diff).

Thoughts?