### PR TITLE
bug(api): correctly sort visits

### DIFF
--- a/server/db/db.js
+++ b/server/db/db.js
@@ -50,8 +50,8 @@ module.exports = {
     _trace('db.getPaginatedVisits', arguments);
     var query = 'SELECT id, url, urlHash, title, visitedAt ' +
                 'FROM visits WHERE fxaId = ? ' +
-                'AND visitedAt > (SELECT visitedAt FROM visits WHERE id = ?) ' +
-                'ORDER BY visitedAt LIMIT ?';
+                'AND visitedAt < (SELECT visitedAt FROM visits WHERE id = ?) ' +
+                'ORDER BY visitedAt DESC LIMIT ?';
     pool.query(query, [fxaId, visitId, count], function(err, results) {
       cb(err, results);
     });
@@ -59,7 +59,7 @@ module.exports = {
   getVisits: function(fxaId, count, cb) {
     _trace('db.getVisits', arguments);
     var query = 'SELECT id, url, urlHash, title, visitedAt ' +
-                'FROM visits WHERE fxaId=? ORDER BY visitedAt LIMIT ?';
+                'FROM visits WHERE fxaId=? ORDER BY visitedAt DESC LIMIT ?';
     pool.query(query, [fxaId, count], function(err, results) {
       cb(err, results);
     });


### PR DESCRIPTION
Yikes, dunno how I missed this.

We want to return the paged visit data in reverse chronological order: newest records first, older records later.

To test this PR actually fixed the pagination behavior:

1. `node server/db/create_db.js`
2. `node server/db/create_test_data.js --count 100` to get several pages of records
3. `npm start`
4. the first page of data should start at number 99 and move backwards through time to number 75: `localhost:8080/v1/visits`
5. grab the ID from the last item on the first page, put it in the URL, and you should see the second page of results, from number 74 to number 50: `localhost:8080/v1/visits?visitId=whatever`

@nchapman mind having a look?