### PR TITLE
bug(server): reduce server verbosity

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,9 +9,12 @@ var config = require('./config');
 var log = require('./logger')('server.index');
 var routes = require('./routes');
 var visits = require('./visits');
+var serverConfig = {};
 
-// log extra error info if we're developing locally
-var serverConfig = (config.get('env') === 'local' ? {debug: {request: ['error']}} : {});
+// log extra error info if we're in ultra-chatty log mode
+if (config.get('server.log.level') === 'trace') {
+  serverConfig = {debug: {request: ['error']}};
+}
 
 var server = new Hapi.Server(serverConfig);
 server.connection({

--- a/server/visits.js
+++ b/server/visits.js
@@ -39,7 +39,7 @@ var routes = [{
         fxaId = fxaId || config.get('testUser.id');
       }
       var visitId = request.query.visitId;
-      log.info('fxaId is ' + fxaId);
+      log.trace('fxaId is ' + fxaId);
 
       function onResults(err, results) {
         if (err) {


### PR DESCRIPTION
Fixes #65.

This hides the server error text when the logging level is set to anything lower than 'trace', as well as the one log call that was spitting out the fxaId in one of the visits routes.