### PR TITLE
Fixup auth

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,21 @@
 
 TODO: formally document supported HTTP status codes, format of error and success responses, HTTPS cookie requirements, and which requirements are relaxed when developing locally.
 
+### Auth API
+
+Chronicle uses Firefox Accounts to log users in, but manages its own session duration.
+
+The session cookie is encrypted server-side, so it is not accessible to the client-side code.
+
+The Firefox Accounts OAuth flow is handled by the server; the front-end just needs to redirect logged-out users to the `/auth/login` endpoint.
+
+Note, if the `testUser` config option is set, the cookie will be created directly by visiting `/auth/login`, ignoring the OAuth step.
+
+### Auth API Methods
+
+- Start the login flow: `GET /auth/login`
+- Logout: `GET /auth/logout`
+
 ### Visits API
 
 A `Visit` is a representation of a user's visit to a website at a particular time. Endpoints that return multiple `Visits` return them as simple lists (arrays) of `Visit` objects.
@@ -35,7 +50,7 @@ Note that the `Visit` object returned to a given user never contains that user's
   - This is the format returned by `Date.toJSON()` in modern browsers.
   - See notes section below for a discussion of our choice of timestamp format.
 
-### API Methods
+### Visits API Methods
 
 Note: Partial updates via `PATCH` are not currently supported, but we can add support later to optimize network traffic.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,12 +9,12 @@
       "dependencies": {
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@2.x.x",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -26,7 +26,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -53,32 +53,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -87,7 +87,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -111,12 +111,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -130,22 +130,22 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@~0.4.2",
+      "from": "grunt@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -155,37 +155,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -194,2288 +194,142 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.8",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
-        }
-      }
-    },
-    "grunt-autoprefixer": {
-      "version": "2.1.0",
-      "from": "grunt-autoprefixer@2.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.1.0.tgz",
-      "dependencies": {
-        "autoprefixer-core": {
-          "version": "4.0.2",
-          "from": "autoprefixer-core@^4.0.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-4.0.2.tgz",
-          "dependencies": {
-            "caniuse-db": {
-              "version": "1.0.30000043",
-              "from": "caniuse-db@^1.0.30000030",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000043.tgz"
-            },
-            "postcss": {
-              "version": "3.0.7",
-              "from": "postcss@~3.0.6",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-3.0.7.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.43",
-                  "from": "source-map@~0.1.40",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                    }
-                  }
-                },
-                "js-base64": {
-                  "version": "2.1.6",
-                  "from": "js-base64@~2.1.5",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.6.tgz"
-                }
-              }
-            }
-          }
-        },
-        "diff": {
-          "version": "1.2.1",
-          "from": "diff@~1.2.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.2.1.tgz"
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-contrib-clean": {
-      "version": "0.6.0",
-      "from": "grunt-contrib-clean@0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@~2.2.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        }
-      }
-    },
-    "grunt-contrib-copy": {
-      "version": "0.7.0",
-      "from": "grunt-contrib-copy@0.7.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.7.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-contrib-jshint": {
-      "version": "0.10.0",
-      "from": "grunt-contrib-jshint@0.10.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
-      "dependencies": {
-        "jshint": {
-          "version": "2.5.11",
-          "from": "jshint@",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
-          "dependencies": {
-            "cli": {
-              "version": "0.6.5",
-              "from": "cli@0.6.x",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@~ 3.2.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "from": "console-browserify@1.1.x",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-              "dependencies": {
-                "date-now": {
-                  "version": "0.1.4",
-                  "from": "date-now@^0.1.4",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-                }
-              }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@0.1.x",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "htmlparser2": {
-              "version": "3.8.2",
-              "from": "htmlparser2@3.8.x",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0",
-                  "from": "domhandler@2.3",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-                },
-                "domutils": {
-                  "version": "1.5.0",
-                  "from": "domutils@1.5",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
-                },
-                "domelementtype": {
-                  "version": "1.1.3",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0",
-                  "from": "entities@1.0",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "minimatch@1.0.x",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@0.3.x",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "strip-json-comments@1.0.x",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "underscore": {
-              "version": "1.6.0",
-              "from": "underscore@1.6.x",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-            }
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        }
-      }
-    },
-    "grunt-contrib-watch": {
-      "version": "0.6.1",
-      "from": "grunt-contrib-watch@0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "dependencies": {
-        "gaze": {
-          "version": "0.5.1",
-          "from": "gaze@~0.5.1",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "globule@~0.1.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.1",
-                  "from": "lodash@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "glob@~3.1.21",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "inherits@1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tiny-lr-fork": {
-          "version": "0.0.5",
-          "from": "tiny-lr-fork@0.0.5",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "qs@~0.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
-            },
-            "faye-websocket": {
-              "version": "0.4.4",
-              "from": "faye-websocket@~0.4.3",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-            },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "noptify@~0.0.3",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "nopt@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@~0.7.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "async@~0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        }
-      }
-    },
-    "grunt-conventional-changelog": {
-      "version": "1.1.0",
-      "from": "grunt-conventional-changelog@1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.1.0.tgz",
-      "dependencies": {
-        "conventional-changelog": {
-          "version": "0.0.6",
-          "from": "conventional-changelog@0.0.6",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
-          "dependencies": {
-            "lodash.assign": {
-              "version": "2.4.1",
-              "from": "lodash.assign@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-              "dependencies": {
-                "lodash._basecreatecallback": {
-                  "version": "2.4.1",
-                  "from": "lodash._basecreatecallback@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash.bind": {
-                      "version": "2.4.1",
-                      "from": "lodash.bind@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._createwrapper": {
-                          "version": "2.4.1",
-                          "from": "lodash._createwrapper@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._basebind": {
-                              "version": "2.4.1",
-                              "from": "lodash._basebind@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._basecreate": {
-                                  "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                                  "dependencies": {
-                                    "lodash._isnative": {
-                                      "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                    },
-                                    "lodash.noop": {
-                                      "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                    }
-                                  }
-                                },
-                                "lodash.isobject": {
-                                  "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash._basecreatewrapper": {
-                              "version": "2.4.1",
-                              "from": "lodash._basecreatewrapper@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._basecreate": {
-                                  "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                                  "dependencies": {
-                                    "lodash._isnative": {
-                                      "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                    },
-                                    "lodash.noop": {
-                                      "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                    }
-                                  }
-                                },
-                                "lodash.isobject": {
-                                  "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash.isfunction": {
-                              "version": "2.4.1",
-                              "from": "lodash.isfunction@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-                            }
-                          }
-                        },
-                        "lodash._slice": {
-                          "version": "2.4.1",
-                          "from": "lodash._slice@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.identity": {
-                      "version": "2.4.1",
-                      "from": "lodash.identity@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
-                    },
-                    "lodash._setbinddata": {
-                      "version": "2.4.1",
-                      "from": "lodash._setbinddata@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash.noop": {
-                          "version": "2.4.1",
-                          "from": "lodash.noop@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.support": {
-                      "version": "2.4.1",
-                      "from": "lodash.support@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash.keys": {
-                  "version": "2.4.1",
-                  "from": "lodash.keys@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "lodash._isnative@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    },
-                    "lodash.isobject": {
-                      "version": "2.4.1",
-                      "from": "lodash.isobject@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "from": "lodash._shimkeys@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash._objecttypes": {
-                  "version": "2.4.1",
-                  "from": "lodash._objecttypes@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                }
-              }
-            },
-            "event-stream": {
-              "version": "3.1.7",
-              "from": "event-stream@~3.1.0",
-              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-              "dependencies": {
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                },
-                "duplexer": {
-                  "version": "0.1.1",
-                  "from": "duplexer@~0.1.1",
-                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-                },
-                "from": {
-                  "version": "0.1.3",
-                  "from": "from@~0",
-                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-                },
-                "map-stream": {
-                  "version": "0.1.0",
-                  "from": "map-stream@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-                },
-                "pause-stream": {
-                  "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
-                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-                },
-                "split": {
-                  "version": "0.2.10",
-                  "from": "split@0.2",
-                  "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
-                },
-                "stream-combiner": {
-                  "version": "0.0.4",
-                  "from": "stream-combiner@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "grunt-copyright": {
-      "version": "0.1.0",
-      "from": "grunt-copyright@0.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
-    },
-    "grunt-git-contributors": {
-      "version": "0.1.5",
-      "from": "grunt-git-contributors@0.1.5",
-      "resolved": "https://registry.npmjs.org/grunt-git-contributors/-/grunt-git-contributors-0.1.5.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "2.2.1",
-          "from": "lodash@~2.2.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
-        }
-      }
-    },
-    "grunt-hapi": {
-      "version": "0.8.1",
-      "from": "grunt-hapi@0.8.1",
-      "resolved": "https://registry.npmjs.org/grunt-hapi/-/grunt-hapi-0.8.1.tgz"
-    },
-    "grunt-jscs": {
-      "version": "1.1.0",
-      "from": "grunt-jscs@1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.1.0.tgz",
-      "dependencies": {
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "jscs": {
-          "version": "1.9.0",
-          "from": "jscs@~1.9.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.9.0.tgz",
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "from": "colors@~1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            },
-            "commander": {
-              "version": "2.5.1",
-              "from": "commander@~2.5.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
-            },
-            "esprima": {
-              "version": "1.2.2",
-              "from": "esprima@~1.2.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
-            },
-            "esprima-harmony-jscs": {
-              "version": "1.1.0-dev-harmony",
-              "from": "esprima-harmony-jscs@1.1.0-dev-harmony",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz"
-            },
-            "estraverse": {
-              "version": "1.8.0",
-              "from": "estraverse@~1.8.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.8.0.tgz"
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@~0.1.2",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "glob": {
-              "version": "4.0.6",
-              "from": "glob@~4.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.5",
-                  "from": "graceful-fs@^3.0.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "from": "once@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "minimatch@~1.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "strip-json-comments@~1.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "vow-fs": {
-              "version": "0.3.4",
-              "from": "vow-fs@~0.3.1",
-              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
-              "dependencies": {
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@^1.4.2",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "vow-queue": {
-                  "version": "0.4.1",
-                  "from": "vow-queue@^0.4.1",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
-                },
-                "glob": {
-                  "version": "4.3.2",
-                  "from": "glob@^4.3.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.2.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.1",
-                      "from": "minimatch@^2.0.1",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "brace-expansion@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "balanced-match@^0.2.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.1",
-                      "from": "once@^1.3.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "xmlbuilder": {
-              "version": "2.4.5",
-              "from": "xmlbuilder@~2.4.0",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.5.tgz",
-              "dependencies": {
-                "lodash-node": {
-                  "version": "2.4.1",
-                  "from": "lodash-node@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "1.2.0",
-              "from": "supports-color@~1.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
-            },
-            "unicode-6.3.0": {
-              "version": "0.1.5",
-              "from": "unicode-6.3.0@~0.1.5",
-              "resolved": "https://registry.npmjs.org/unicode-6.3.0/-/unicode-6.3.0-0.1.5.tgz"
-            },
-            "regenerate": {
-              "version": "1.0.1",
-              "from": "regenerate@~1.0.1",
-              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.0.1.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "vow": {
-          "version": "0.4.7",
-          "from": "vow@~0.4.1",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.7.tgz"
-        }
-      }
-    },
-    "grunt-jsonlint": {
-      "version": "1.0.4",
-      "from": "grunt-jsonlint@1.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
-      "dependencies": {
-        "jsonlint": {
-          "version": "1.6.0",
-          "from": "jsonlint@1.6.0",
-          "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
-          "dependencies": {
-            "nomnom": {
-              "version": "1.8.1",
-              "from": "nomnom@>= 1.5.x",
-              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.6.0",
-                  "from": "underscore@~1.6.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-                },
-                "chalk": {
-                  "version": "0.4.0",
-                  "from": "chalk@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                  "dependencies": {
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "has-color@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "1.0.0",
-                      "from": "ansi-styles@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "0.1.1",
-                      "from": "strip-ansi@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "JSV": {
-              "version": "4.0.2",
-              "from": "JSV@>= 4.0.x",
-              "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-nsp-shrinkwrap": {
-      "version": "0.0.3",
-      "from": "grunt-nsp-shrinkwrap@0.0.3",
-      "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
-      "dependencies": {
-        "cli-color": {
-          "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
-          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-          "dependencies": {
-            "es5-ext": {
-              "version": "0.9.2",
-              "from": "es5-ext@~0.9.2",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
-            },
-            "memoizee": {
-              "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
-              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-              "dependencies": {
-                "event-emitter": {
-                  "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
-                },
-                "next-tick": {
-                  "version": "0.1.0",
-                  "from": "next-tick@0.1.x",
-                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "colors": {
-          "version": "0.6.2",
-          "from": "colors@^0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-        },
-        "grunt": {
-          "version": "0.4.5",
-          "from": "grunt@~0.4.5",
-          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.1.22",
-              "from": "async@~0.1.22",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
-            },
-            "coffee-script": {
-              "version": "1.3.3",
-              "from": "coffee-script@~1.3.3",
-              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
-            },
-            "dateformat": {
-              "version": "1.0.2-1.2.3",
-              "from": "dateformat@1.0.2-1.2.3",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
-            },
-            "eventemitter2": {
-              "version": "0.4.14",
-              "from": "eventemitter2@~0.4.13",
-              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
-            },
-            "findup-sync": {
-              "version": "0.1.3",
-              "from": "findup-sync@~0.1.2",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@~3.2.9",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "3.1.21",
-              "from": "glob@~3.1.21",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                },
-                "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                }
-              }
-            },
-            "hooker": {
-              "version": "0.2.3",
-              "from": "hooker@~0.2.3",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-            },
-            "iconv-lite": {
-              "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
-            },
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@~0.2.12",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "nopt": {
-              "version": "1.0.10",
-              "from": "nopt@~1.0.10",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.5",
-                  "from": "abbrev@1",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@~2.2.8",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            },
-            "lodash": {
-              "version": "0.9.2",
-              "from": "lodash@~0.9.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
-            },
-            "underscore.string": {
-              "version": "2.2.1",
-              "from": "underscore.string@~2.2.1",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
-            },
-            "which": {
-              "version": "1.0.8",
-              "from": "which@~1.0.5",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
-            },
-            "js-yaml": {
-              "version": "2.0.5",
-              "from": "js-yaml@~2.0.5",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-                  "dependencies": {
-                    "underscore.string": {
-                      "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0",
-                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                }
-              }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@~0.1.1",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "getobject": {
-              "version": "0.1.0",
-              "from": "getobject@~0.1.0",
-              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
-            },
-            "grunt-legacy-util": {
-              "version": "0.2.0",
-              "from": "grunt-legacy-util@~0.2.0",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
-            },
-            "grunt-legacy-log": {
-              "version": "0.1.1",
-              "from": "grunt-legacy-log@~0.1.0",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                },
-                "underscore.string": {
-                  "version": "2.3.3",
-                  "from": "underscore.string@~2.3.3",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-                }
-              }
-            }
-          }
-        },
-        "request": {
-          "version": "2.51.0",
-          "from": "request@^2.34.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-          "dependencies": {
-            "bl": {
-              "version": "0.9.3",
-              "from": "bl@~0.9.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.8.0",
-              "from": "caseless@~0.8.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "from": "forever-agent@~0.5.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@~0.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.0",
-                  "from": "async@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.0.7",
-                  "from": "mime-types@~2.0.3",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.5.0",
-                      "from": "mime-db@~1.5.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-            },
-            "mime-types": {
-              "version": "1.0.2",
-              "from": "mime-types@~1.0.1",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "qs@~2.3.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-            },
-            "tough-cookie": {
-              "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.5.0",
-              "from": "oauth-sign@~0.5.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-            },
-            "hawk": {
-              "version": "1.1.1",
-              "from": "hawk@1.1.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "0.9.1",
-                  "from": "hoek@0.9.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                },
-                "boom": {
-                  "version": "0.4.2",
-                  "from": "boom@0.4.x",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                },
-                "cryptiles": {
-                  "version": "0.2.2",
-                  "from": "cryptiles@0.2.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                },
-                "sntp": {
-                  "version": "0.2.4",
-                  "from": "sntp@0.2.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@~0.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@~0.2",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "grunt-requirejs": {
-      "version": "0.4.2",
-      "from": "grunt-requirejs@0.4.2",
-      "resolved": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
-      "dependencies": {
-        "requirejs": {
-          "version": "2.1.15",
-          "from": "requirejs@2.1.x",
-          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.15.tgz"
-        },
-        "cheerio": {
-          "version": "0.13.1",
-          "from": "cheerio@0.13.x",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
-          "dependencies": {
-            "htmlparser2": {
-              "version": "3.4.0",
-              "from": "htmlparser2@~3.4.0",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.2.1",
-                  "from": "domhandler@2.2",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
-                },
-                "domutils": {
-                  "version": "1.3.0",
-                  "from": "domutils@1.3",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
-                },
-                "domelementtype": {
-                  "version": "1.1.3",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "underscore": {
-              "version": "1.5.2",
-              "from": "underscore@~1.5",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
-            },
-            "entities": {
-              "version": "0.5.0",
-              "from": "entities@0.x",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
-            },
-            "CSSselect": {
-              "version": "0.4.1",
-              "from": "CSSselect@~0.4.0",
-              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-              "dependencies": {
-                "CSSwhat": {
-                  "version": "0.4.7",
-                  "from": "CSSwhat@0.4",
-                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
-                },
-                "domutils": {
-                  "version": "1.4.3",
-                  "from": "domutils@1.4",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.1.3",
-                      "from": "domelementtype@1",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "almond": {
-          "version": "0.2.9",
-          "from": "almond@0.2.x",
-          "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
-        },
-        "gzip-js": {
-          "version": "0.3.2",
-          "from": "gzip-js@0.3.x",
-          "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
-          "dependencies": {
-            "crc32": {
-              "version": "0.2.2",
-              "from": "crc32@>= 0.2.2",
-              "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
-            },
-            "deflate-js": {
-              "version": "0.2.3",
-              "from": "deflate-js@>= 0.2.2",
-              "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
-            }
-          }
-        },
-        "q": {
-          "version": "0.8.12",
-          "from": "q@0.8.x",
-          "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
-        }
-      }
-    },
-    "grunt-rev": {
-      "version": "0.1.0",
-      "from": "grunt-rev@0.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
-    },
-    "grunt-sass": {
-      "version": "0.17.0",
-      "from": "grunt-sass@0.17.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.17.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "each-async": {
-          "version": "1.1.1",
-          "from": "each-async@^1.0.0",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-          "dependencies": {
-            "onetime": {
-              "version": "1.0.0",
-              "from": "onetime@^1.0.0",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
-            },
-            "set-immediate-shim": {
-              "version": "1.0.0",
-              "from": "set-immediate-shim@^1.0.0",
-              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
-            }
-          }
-        },
-        "node-sass": {
-          "version": "1.2.3",
-          "from": "node-sass@1.2.3",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-1.2.3.tgz",
-          "dependencies": {
-            "cross-spawn": {
-              "version": "0.2.3",
-              "from": "cross-spawn@^0.2.3",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.3.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@^2.5.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                }
-              }
-            },
-            "gaze": {
-              "version": "0.5.1",
-              "from": "gaze@^0.5.1",
-              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-              "dependencies": {
-                "globule": {
-                  "version": "0.1.0",
-                  "from": "globule@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "1.0.1",
-                      "from": "lodash@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
-                    },
-                    "glob": {
-                      "version": "3.1.21",
-                      "from": "glob@~3.1.21",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@~1.2.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                        },
-                        "inherits": {
-                          "version": "1.0.0",
-                          "from": "inherits@1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "get-stdin": {
-              "version": "3.0.2",
-              "from": "get-stdin@^3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-            },
-            "meow": {
-              "version": "2.1.0",
-              "from": "meow@^2.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.0.2",
-                      "from": "camelcase@^1.0.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.0",
-                      "from": "map-obj@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                    }
-                  }
-                },
-                "indent-string": {
-                  "version": "1.2.0",
-                  "from": "indent-string@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "1.1.1",
-                      "from": "repeating@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.0",
-                          "from": "is-finite@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "1.1.0",
-                  "from": "minimist@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "object-assign@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@^0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "mocha": {
-              "version": "2.1.0",
-              "from": "mocha@^2.0.1",
-              "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.3.0",
-                  "from": "commander@2.3.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-                },
-                "debug": {
-                  "version": "2.0.0",
-                  "from": "debug@2.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "diff": {
-                  "version": "1.0.8",
-                  "from": "diff@1.0.8",
-                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.2",
-                  "from": "escape-string-regexp@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.2.3",
-                  "from": "glob@3.2.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "growl": {
-                  "version": "1.8.1",
-                  "from": "growl@1.8.1",
-                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
-                },
-                "jade": {
-                  "version": "0.26.3",
-                  "from": "jade@0.26.3",
-                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "nan": {
-              "version": "1.4.1",
-              "from": "nan@^1.3.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
-            },
-            "object-assign": {
-              "version": "1.0.0",
-              "from": "object-assign@^1.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "request": {
-              "version": "2.51.0",
-              "from": "request@^2.48.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "0.9.3",
-                  "from": "bl@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.8.0",
-                  "from": "caseless@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                },
-                "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.9.0",
-                      "from": "async@~0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.0.7",
-                      "from": "mime-types@~2.0.3",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.5.0",
-                          "from": "mime-db@~1.5.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-                },
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                },
-                "tough-cookie": {
-                  "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.5.0",
-                  "from": "oauth-sign@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-                },
-                "hawk": {
-                  "version": "1.1.1",
-                  "from": "hawk@1.1.1",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@0.9.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@^0.3.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "object-assign@^2.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-        }
-      }
-    },
-    "grunt-template": {
-      "version": "0.2.3",
-      "from": "grunt-template@0.2.3",
-      "resolved": "https://registry.npmjs.org/grunt-template/-/grunt-template-0.2.3.tgz"
-    },
-    "grunt-todo": {
-      "version": "0.4.0",
-      "from": "grunt-todo@0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@~0.2",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "grunt-usemin": {
-      "version": "3.0.0",
-      "from": "grunt-usemin@3.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-3.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "debug": {
-          "version": "2.1.1",
-          "from": "debug@~2.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2",
-              "from": "ms@0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
     },
@@ -2506,17 +360,17 @@
           "dependencies": {
             "joi": {
               "version": "4.9.0",
-              "from": "joi@4.x.x",
+              "from": "joi@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "isemail@1.x.x",
+                  "from": "isemail@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.9.0",
-                  "from": "moment@2.x.x",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
                 }
               }
@@ -2684,7 +538,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -2696,59 +550,59 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@^2.2.x",
+          "from": "hoek@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.x.x",
+          "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "isemail@1.x.x",
+          "from": "isemail@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
           "version": "2.9.0",
-          "from": "moment@2.x.x",
+          "from": "moment@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
         }
       }
     },
     "jshint": {
       "version": "2.5.11",
-      "from": "jshint@",
+      "from": "jshint@*",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.5",
-          "from": "cli@0.6.x",
+          "from": "cli@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~ 3.2.1",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2759,49 +613,49 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@1.1.x",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@^0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.x",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@3.8.x",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@2.3",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.0",
-              "from": "domutils@1.5",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
             },
             "domelementtype": {
               "version": "1.1.3",
-              "from": "domelementtype@1",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@1.1",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -2811,258 +665,54 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@1.0.x",
+          "from": "minimatch@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "shelljs@0.3.x",
+          "from": "shelljs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@1.0.x",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@1.6.x",
+          "from": "underscore@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "jshint-stylish": {
-      "version": "1.0.0",
-      "from": "jshint-stylish@1.0.0",
-      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.1",
-          "from": "log-symbols@^1.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
-        },
-        "string-length": {
-          "version": "1.0.0",
-          "from": "string-length@^1.0.0",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
-          "dependencies": {
-            "strip-ansi": {
-              "version": "2.0.0",
-              "from": "strip-ansi@^2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "1.1.0",
-                  "from": "ansi-regex@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@^0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "load-grunt-tasks": {
-      "version": "2.0.0",
-      "from": "load-grunt-tasks@2.0.0",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-2.0.0.tgz",
-      "dependencies": {
-        "findup-sync": {
-          "version": "0.2.1",
-          "from": "findup-sync@^0.2.1",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.3.2",
-              "from": "glob@~4.3.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.2.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.1",
-                  "from": "minimatch@^2.0.1",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "from": "once@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "multimatch": {
-          "version": "2.0.0",
-          "from": "multimatch@^2.0.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-union": {
-              "version": "1.0.1",
-              "from": "array-union@^1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@^1.0.1",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.1",
-              "from": "minimatch@^2.0.1",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -3073,85 +723,85 @@
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@^1.0.0",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.2",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "strftime@~0.8.2",
+              "from": "strftime@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@^1.2.0",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
@@ -3168,12 +818,12 @@
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@~1.1.13",
+          "from": "readable-stream@>=1.1.13 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
@@ -3183,12 +833,12 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@~0.10.x",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -3199,11 +849,6 @@
           "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
         }
       }
-    },
-    "precommit-hook": {
-      "version": "1.0.7",
-      "from": "precommit-hook@1.0.7",
-      "resolved": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz"
     },
     "underscore": {
       "version": "1.7.0",
@@ -3222,7 +867,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }

--- a/server/bell_oauth_profile.js
+++ b/server/bell_oauth_profile.js
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var log = require('./logger')('server.bell.profile');
+var db = require('./db/db');
+var config = require('./config');
+
+// this is the custom provider profile function used by Bell to allow us
+// to convert oauth tokens into profile information.
+function profile (credentials, params, get, profileCb) {
+  log.verbose('obtained oauth tokens: ' + JSON.stringify(credentials));
+  var headers = { headers: {'authorization': 'Bearer ' + params.access_token} };
+  get(config.get('server.oauth.profileEndpoint'), headers, function(data) {
+    // Bell returns the parsed data and handles errors internally
+    log.verbose('exchanged tokens for profile data:' + JSON.stringify(data));
+    // TODO use Joi to validate `data` before sending to DB
+    db.getUserById(data.uid, function (err, user) {
+      if (err) {
+        log.warn('getUserById failed: ' + err);
+        return profileCb('getUserById failed: ' + err);
+      }
+      if (user) {
+        log.verbose('user exists! updating oauth token and setting session cookie...');
+        db.updateUser(data.uid, data.email, params.access_token, function(err) {
+          if (err) {
+            log.warn('updateUser failed: ' + err);
+            return profileCb('logging in user failed: ' + err);
+          }
+          // finally, set the cookie and redirect.
+          log.verbose('logged in existing user ' + data.email);
+          credentials.profile = {fxaId: data.uid};
+          return profileCb(null, credentials);
+        });
+      } else {
+        log.verbose('new user! creating record and setting session cookie...');
+        db.createUser(data.uid, data.email, params.access_token, function(err) {
+          if (err) {
+            log.warn('user creation failed: ' + err);
+            return profileCb('creating new user failed: ' + err);
+          }
+          log.verbose('created new user ' + data.email);
+          credentials.profile = {fxaId: data.uid, isNewUser: true};
+          return profileCb(null, credentials);
+        });
+      }
+    });
+  });
+}
+module.exports = profile;

--- a/server/config.js
+++ b/server/config.js
@@ -9,8 +9,6 @@ var path = require('path');
 
 var convict = require('convict');
 
-var SEVEN_DAYS_IN_MSEC = 1000 * 60 * 60 * 24 * 7; // 7 days
-
 var conf = convict({
   env: {
     doc: 'Application environment.',
@@ -217,16 +215,22 @@ var conf = convict({
         env: 'SESSION_ALLOW_INSECURE_COOKIES'
       },
       duration: {
-        doc: 'Default session TTL for authenticated users.',
+        doc: 'Session duration in milliseconds. Zero, the default, means session cookie.',
         format: 'int',
-        default: SEVEN_DAYS_IN_MSEC,
+        default: 0,
         env: 'SESSION_DURATION'
       },
-      id: {
+      cookieName: {
         doc: 'Name of session cookie.',
-        default: 'sid-chronicle',
-        env: 'SESSION_ID',
-        format: String
+        default: 'sid',
+        format: String,
+        env: 'SESSION_COOKIE_NAME'
+      },
+      clearInvalid: {
+        doc: 'Whether to expire cookies that fail validation.',
+        default: true,
+        format: Boolean,
+        env: 'SESSION_COOKIE_CLEAR_INVALID'
       }
     }
   }

--- a/server/db/utils.js
+++ b/server/db/utils.js
@@ -28,7 +28,7 @@ module.exports = {
     // otherwise time debugging will be hilariously jumbled
     if (config.get('env') === 'local') {
       pool.on('connection', function onConnection(connection) {
-        log.trace('pool "connection" event fired, setting timezone');
+        log.verbose('pool "connection" event fired, setting timezone');
         connection.query('SET time_zone=?', '+00:00');
       });
     }
@@ -36,7 +36,7 @@ module.exports = {
     // TODO is this the right way to ensure pool shutdown?
     // shutdown the pool on process shutdown
     process.on('exit', function onExit() {
-      log.trace('received exit signal, closing pool');
+      log.verbose('received exit signal, closing pool');
       pool.end();
     });
 

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,6 @@ var config = require('./config');
 var log = require('./logger')('server.index');
 var authProfileCb = require('./bell_oauth_profile');
 var routes = require('./routes');
-var visits = require('./visits');
 var serverConfig = {};
 var db = require('./db/db');
 
@@ -85,6 +84,5 @@ server.register([
 
 // register routes
 server.route(routes);
-server.route(visits);
 
 module.exports = server;

--- a/server/index.js
+++ b/server/index.js
@@ -48,11 +48,6 @@ server.register([
       log.verbose('inside hapi-auth-cookie validateFunc.');
       log.verbose('session is ' + JSON.stringify(session));
 
-      // special case the situation where test user is enabled
-      if (config.get('testUser.enabled')) {
-        return cb(null, true, config.get('testUser.id'));
-      }
-
       var ttl = config.get('server.session.duration');
       if (ttl > 0 && new Date() > new Date(session.expiresAt)) {
         log.verbose('cookie is expired.');

--- a/server/routes.js
+++ b/server/routes.js
@@ -27,7 +27,9 @@ module.exports = [{
       }
     },
     handler: function (request, reply) {
-      var page = request.auth.isAuthenticated ? 'app.html' : 'index.html';
+      // TODO: have a separate logged-in view :-)
+      // var page = request.auth.isAuthenticated ? 'app.html' : 'index.html';
+      var page = 'index.html';
       reply.file(path.join(STATIC_PATH, page));
     }
   }
@@ -45,6 +47,12 @@ module.exports = [{
       }
     },
     handler: function(request, reply) {
+      // If we are in testUser mode, just set the cookie and skip the oauth part
+      if (config.get('testUser.enabled')) {
+        request.auth.session.set({fxaId: config.get('testUser.id')});
+        return reply.redirect('/');
+      }
+
       // Bell uses the same endpoint for both the start and redirect
       // steps in the flow. Let's keep this as the initial endpoint,
       // so the API is easy to read, and just redirect the user.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -4,36 +4,10 @@
 
 'use strict';
 
-var path = require('path');
-var uuid = require('uuid');
-
-var log = require('./logger')('server.routes');
-var config = require('./config');
-
-var STATIC_PATH = path.join(__dirname, '..', config.get('server.staticPath'));
+var log = require('../logger')('server.routes.auth');
+var config = require('../config');
 
 module.exports = [{
-  method: 'GET',
-  path: '/',
-  config: {
-    auth: {
-      strategy: 'session',
-      // 'try': allow users to visit the route with good, bad, or no session
-      mode: 'try'
-    },
-    plugins: {
-      'hapi-auth-cookie': {
-        redirectTo: false // don't redirect users who don't have a session
-      }
-    },
-    handler: function (request, reply) {
-      // TODO: have a separate logged-in view :-)
-      // var page = request.auth.isAuthenticated ? 'app.html' : 'index.html';
-      var page = 'index.html';
-      reply.file(path.join(STATIC_PATH, page));
-    }
-  }
-}, {
   method: 'GET',
   path: '/auth/login',
   config: {
@@ -103,15 +77,6 @@ module.exports = [{
       }
       request.auth.session.set(session);
       reply.redirect('/');
-    }
-  }
-}, {
-  method: 'GET',
-  path: '/{param*}',
-  handler: {
-    directory: {
-      path: STATIC_PATH,
-      listing: config.get('server.staticDirListing')
     }
   }
 }];

--- a/server/routes/base.js
+++ b/server/routes/base.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var path = require('path');
+var log = require('../logger')('server.routes.base');
+var config = require('../config');
+var STATIC_PATH = path.join(__dirname, '../..', config.get('server.staticPath'));
+
+module.exports = [{
+  method: 'GET',
+  path: '/',
+  config: {
+    auth: {
+      strategy: 'session',
+      // 'try': allow users to visit the route with good, bad, or no session
+      mode: 'try'
+    },
+    plugins: {
+      'hapi-auth-cookie': {
+        redirectTo: false // don't redirect users who don't have a session
+      }
+    },
+    handler: function (request, reply) {
+      // TODO: have a separate logged-in view :-)
+      // var page = request.auth.isAuthenticated ? 'app.html' : 'index.html';
+      var page = 'index.html';
+      reply.file(path.join(STATIC_PATH, page));
+    }
+  }
+}, {
+  method: 'GET',
+  path: '/{param*}',
+  handler: {
+    directory: {
+      path: STATIC_PATH,
+      listing: config.get('server.staticDirListing')
+    }
+  }
+}];

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+module.exports = [].concat(require('./base'), require('./auth'), require('./visits'));

--- a/server/routes/visits.js
+++ b/server/routes/visits.js
@@ -7,15 +7,14 @@
 var Joi = require('joi');
 var Boom = require('boom');
 var uuid = require('uuid');
-var db = require('./db/db');
-var log = require('./logger')('server.visits');
-var config = require('./config');
+var db = require('../db/db');
+var log = require('../logger')('server.routes.visits');
+var config = require('../config');
 
 // TODO: add additional metadata fields to the visit datatype
 // TODO: normalize URLs
-// TODO: visits pagination
 
-var routes = [{
+module.exports = [{
   method: 'GET',
   path: '/v1/visits',
   config: {
@@ -135,7 +134,7 @@ var routes = [{
             log.warn(err);
             return reply(Boom.create(500));
           }
-          // unlike GET visit above, we assume 500 would have hit before you 
+          // unlike GET visit above, we assume 500 would have hit before you
           // discover there's actually no record with that ID
           reply(result);
         });
@@ -164,5 +163,3 @@ var routes = [{
     }
   }
 }];
-
-module.exports = routes;

--- a/server/visits.js
+++ b/server/visits.js
@@ -13,19 +13,13 @@ var config = require('./config');
 
 // TODO: add additional metadata fields to the visit datatype
 // TODO: normalize URLs
-// TODO actually create a session for the fake user
 // TODO: visits pagination
 
 var routes = [{
   method: 'GET',
   path: '/v1/visits',
   config: {
-    // TODO allowing unauthenticated access temporarily
-    // auth: 'session',
-    auth: {
-      strategy: 'session',
-      mode: 'try'
-    },
+    auth: 'session',
     validate: {
       query: {
         count: Joi.number().integer().min(1).max(100).default(25),
@@ -39,7 +33,7 @@ var routes = [{
         fxaId = fxaId || config.get('testUser.id');
       }
       var visitId = request.query.visitId;
-      log.trace('fxaId is ' + fxaId);
+      log.verbose('fxaId is ' + fxaId);
 
       function onResults(err, results) {
         if (err) {
@@ -61,12 +55,7 @@ var routes = [{
   method: 'GET',
   path: '/v1/visits/{visitId}',
   config: {
-    // TODO allowing unauthenticated access temporarily
-    // auth: 'session',
-    auth: {
-      strategy: 'session',
-      mode: 'try'
-    },
+    auth: 'session',
     validate: {
       params: {
         visitId: Joi.string().guid().required()
@@ -96,12 +85,7 @@ var routes = [{
   method: 'POST',
   path: '/v1/visits',
   config: {
-    // TODO allowing unauthenticated access temporarily
-    // auth: 'session',
-    auth: {
-      strategy: 'session',
-      mode: 'try'
-    },
+    auth: 'session',
     validate: {
       payload: {
         url: Joi.string().required(),
@@ -135,12 +119,7 @@ var routes = [{
   method: 'PUT',
   path: '/v1/visits/{visitId}',
   config: {
-    // TODO allowing unauthenticated access temporarily
-    // auth: 'session',
-    auth: {
-      strategy: 'session',
-      mode: 'try'
-    },
+    auth: 'session',
     validate: {
       // all fields are required, keep life simple for the DB
       payload: {
@@ -190,12 +169,7 @@ var routes = [{
   method: 'DELETE',
   path: '/v1/visits/{visitId}',
   config: {
-    // TODO allowing unauthenticated access temporarily
-    // auth: 'session',
-    auth: {
-      strategy: 'session',
-      mode: 'try'
-    },
+    auth: 'session',
     validate: {
       params: {
         visitId: Joi.string().guid().required()

--- a/server/visits.js
+++ b/server/visits.js
@@ -27,13 +27,8 @@ var routes = [{
       }
     },
     handler: function (request, reply) {
-      var fxaId = (request.auth.session.get && request.auth.session.get('fxaId'));
-      // TODO remove once we have auth working with fake user
-      if (config.get('testUser.enabled')) {
-        fxaId = fxaId || config.get('testUser.id');
-      }
+      var fxaId = request.auth.credentials;
       var visitId = request.query.visitId;
-      log.verbose('fxaId is ' + fxaId);
 
       function onResults(err, results) {
         if (err) {
@@ -62,12 +57,7 @@ var routes = [{
       }
     },
     handler: function (request, reply) {
-      // TODO check fxaId
-      var fxaId = (request.auth.session.get && request.auth.session.get('fxaId'));
-      // TODO remove once we have auth working with fake user
-      if (config.get('testUser.enabled')) {
-        fxaId = fxaId || config.get('testUser.id');
-      }
+      var fxaId = request.auth.credentials;
       db.getVisit(fxaId, request.params.visitId, function(err, result) {
         if (err) {
           log.warn(err);
@@ -96,14 +86,8 @@ var routes = [{
       }
     },
     handler: function(request, reply) {
-      // get fxa id from the cookie
-      // TODO verify that user exists
       var p = request.payload;
-      var fxaId = (request.auth.session.get && request.auth.session.get('fxaId'));
-      // TODO remove this next line once we have auth working with fake user
-      if (config.get('testUser.enabled')) {
-        fxaId = fxaId || config.get('testUser.id');
-      }
+      var fxaId = request.auth.credentials;
       var visitId = p.visitId || uuid.v4();
       db.createVisit(fxaId, visitId, p.visitedAt, p.url, p.title, function (err, visit) {
         if (err) {
@@ -132,14 +116,7 @@ var routes = [{
       }
     },
     handler: function(request, reply) {
-      // le sigh, such handler boilerplate. refactor someday.
-      // get fxa id from the cookie
-      // TODO verify that user exists
-      var fxaId = (request.auth.session.get && request.auth.session.get('fxaId'));
-      // TODO remove this next line once we have auth working with fake user
-      if (config.get('testUser.enabled')) {
-        fxaId = fxaId || config.get('testUser.id');
-      }
+      var fxaId = request.auth.credentials;
       var visitId = request.params.visitId;
       var p = request.payload;
       db.updateVisit(fxaId, visitId, p.visitedAt, p.url, p.title, function(err, result) {
@@ -176,12 +153,7 @@ var routes = [{
       }
     },
     handler: function (request, reply) {
-      // TODO check fxaId
-      var fxaId = (request.auth.session.get && request.auth.session.get('fxaId'));
-      // TODO remove once we have auth working with fake user
-      if (config.get('testUser.enabled')) {
-        fxaId = fxaId || config.get('testUser.id');
-      }
+      var fxaId = request.auth.credentials;
       db.deleteVisit(fxaId, request.params.visitId, function(err) {
         if (err) {
           log.warn(err);


### PR DESCRIPTION
I tried to be a bit more descriptive in the commit messages, as it was a little late to make this stuff a set of atomic commits, but I still wanted to capture some extra detail. I'll just paste those in as a PR description.

When doing local development with the test user, this patch lets you simply surf to /auth/login and a session cookie will be set, skipping the oauth flow completely. All other funky special casing code is gone. Dang, that's nice. (Normally, hitting /auth/login redirects to another endpoint, which redirects to the fxa oauth flow, which eventually ends with a cookie being set, if the oauth stuff worked out successfully.)

Comments welcome!

-----

 chore(server): fixup auth

Correctly use Bell to handle the OAuth nonce. Correctly set and validate
cookies (both that the fxaId exists, and that any TTL hasn't expired).
Fixes #45.

Replace log.trace with log.verbose everywhere, since we never really
want a trace of the function calls.

Enable cookie-based sessions for the visits API, and modify the cookie
validation function to always allow access if the `testUser` config
option is set. Fixes #76.

Add crude placeholder API docs for auth endpoints.

-----

 chore(api): simplify handling of test user

With this patch, we handle the test user by simply setting a cookie as soon as
the user hits the /auth/login endpoint. This is the only bit of special case
code that we need; the cookie is otherwise normal, is validated normally, and
none of the affected routes need any special case code. w00t!
