### PR TITLE
chore(build): renaming npm validate task to validate-shrinkwrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
   - travis_retry npm install
 
 script:
-  - npm run validate # check for vulnerable modules via nodesecurity.io
+  - npm run validate-shrinkwrap # check for vulnerable modules via nodesecurity.io
   - npm run outdated
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "lint": "grunt lint",
     "outdated": "npm outdated --depth 0",
     "postinstall": "bower update --config.interactive=false -s",
-    "shrinkwrap": "npm shrinkwrap --dev && npm run validate",
+    "shrinkwrap": "npm shrinkwrap --dev && npm run validate-shrinkwrap",
     "start": "grunt serve",
     "test": "echo \"Error: no test specified\"",
-    "validate": "grunt validate-shrinkwrap --force"
+    "validate-shrinkwrap": "grunt validate-shrinkwrap --force"
   }
 }


### PR DESCRIPTION
Now the I-will-never-fail `grunt validate-shrinkwrap` task won't get run on every commit via the pre-commit hook.
I just saved you 2s per commit. You're welcome.

Fixes #95 