### PR TITLE
feat(api): add url2png to provide screenshots

### DIFF
--- a/config/local.json.example
+++ b/config/local.json.example
@@ -23,6 +23,10 @@
     "apiKey": "",
     "enabled": true
   },
+  "url2png": {
+    "apiKey": "",
+    "secretKey": ""
+  },
   "server": {
     "host": "127.0.0.1",
     "port": 8080,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -160,7 +160,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -172,7 +172,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -263,7 +263,7 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@>=0.4.2 <0.5.0",
+      "from": "grunt@>=0.4.4 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
@@ -881,7 +881,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -893,7 +893,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -1023,9 +1023,106 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "underscore.string": {
-      "version": "3.0.2",
-      "from": "underscore.string@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.2.tgz"
+      "version": "3.0.1",
+      "from": "underscore.string@3.0.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.1.tgz"
+    },
+    "url2png": {
+      "version": "6.0.1",
+      "from": "url2png@6.0.1",
+      "resolved": "https://registry.npmjs.org/url2png/-/url2png-6.0.1.tgz",
+      "dependencies": {
+        "request": {
+          "version": "2.16.6",
+          "from": "request@>=2.16.0 <2.17.0",
+          "dependencies": {
+            "form-data": {
+              "version": "0.0.10",
+              "from": "form-data@>=0.0.3 <0.1.0",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.7 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.7 <1.3.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "hawk": {
+              "version": "0.10.2",
+              "from": "hawk@>=0.10.2 <0.11.0",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.7.6",
+                  "from": "hoek@>=0.7.0 <0.8.0"
+                },
+                "boom": {
+                  "version": "0.3.8",
+                  "from": "boom@>=0.3.0 <0.4.0"
+                },
+                "cryptiles": {
+                  "version": "0.1.3",
+                  "from": "cryptiles@>=0.1.0 <0.2.0"
+                },
+                "sntp": {
+                  "version": "0.1.4",
+                  "from": "sntp@>=0.1.0 <0.2.0"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.2",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+            },
+            "cookie-jar": {
+              "version": "0.2.0",
+              "from": "cookie-jar@>=0.2.0 <0.3.0"
+            },
+            "aws-sign": {
+              "version": "0.2.0",
+              "from": "aws-sign@>=0.2.0 <0.3.0"
+            },
+            "oauth-sign": {
+              "version": "0.2.0",
+              "from": "oauth-sign@>=0.2.0 <0.3.0"
+            },
+            "forever-agent": {
+              "version": "0.2.0",
+              "from": "forever-agent@>=0.2.0 <0.3.0"
+            },
+            "tunnel-agent": {
+              "version": "0.2.0",
+              "from": "tunnel-agent@>=0.2.0 <0.3.0"
+            },
+            "json-stringify-safe": {
+              "version": "3.0.0",
+              "from": "json-stringify-safe@>=3.0.0 <3.1.0"
+            },
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@>=0.5.4 <0.6.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            }
+          }
+        }
+      }
     },
     "uuid": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "redis": "0.12.1",
     "underscore": "1.7.0",
     "underscore.string": "3.0.1",
+    "url2png": "6.0.1",
     "uuid": "2.0.1",
     "wreck": "5.1.0"
   },

--- a/server/config.js
+++ b/server/config.js
@@ -118,6 +118,7 @@ var conf = convict({
       }
     }
   },
+  // TODO put these under a 'services' namespace
   embedly: {
     enabled: {
       doc: 'Disable embedly for running on travis.',
@@ -137,6 +138,16 @@ var conf = convict({
     // convict doesn't support protocol-relative urls
     format: String,
     default: '//gravatar.com/avatar/'
+  },
+  url2png: {
+    apiKey: {
+      format: String,
+      default: 'your_key_here'
+    },
+    secretKey: {
+      format: String,
+      default: 'your_key_here'
+    }
   },
   server: {
     log: {

--- a/server/controllers/search.js
+++ b/server/controllers/search.js
@@ -6,8 +6,18 @@
 
 var Boom = require('boom');
 
+var config = require('../config');
 var log = require('../logger')('server.controllers.search');
+var url2png = require('url2png')(config.get('url2png.apiKey'), config.get('url2png.secretKey'));
 var visits = require('../models/visits');
+
+function addScreenshots(items) {
+  // XXX this uses different keys than the visit and visits transforms
+  items.forEach(function(item) {
+    item._source.screenshot_url = url2png.buildURL(item._source.url, {viewport: '1024x683', thumbnail_max_width: 540});
+  });
+  return items;
+}
 
 var searchController = {
   get: function (request, reply) {
@@ -18,6 +28,9 @@ var searchController = {
       if (err) {
         log.warn(err);
         return reply(Boom.create(500));
+      }
+      if (results && results.results) {
+        addScreenshots(results.results.hits);
       }
       reply(results);
     });

--- a/server/controllers/visit.js
+++ b/server/controllers/visit.js
@@ -6,8 +6,16 @@
 
 var Boom = require('boom');
 
+var config = require('../config');
 var log = require('../logger')('server.controllers.visit');
+var url2png = require('url2png')(config.get('url2png.apiKey'), config.get('url2png.secretKey'));
 var visit = require('../models/visit');
+
+function addScreenshot(item) {
+  // TODO this is the seed of a view or view helper, believe it or not
+  item.screenshot_url = url2png.buildURL(item.url, {viewport: '1024x683', thumbnail_max_width: 540});
+  return item;
+}
 
 // TODO when we turn this into a real instantiable object, set req, reply as instance vars
 var visitController = {
@@ -21,7 +29,7 @@ var visitController = {
       if (!result) {
         return reply(Boom.create(404, 'Visit not found'));
       } else {
-        reply(result);
+        reply(addScreenshot(result));
       }
     });
   },
@@ -35,7 +43,7 @@ var visitController = {
         return reply(Boom.create(500));
       }
       // return the visit so backbone can update the model
-      reply(result);
+      reply(addScreenshot(result));
     });
   },
   delete: function (request, reply) {

--- a/server/models/visits.js
+++ b/server/models/visits.js
@@ -39,7 +39,7 @@ var visits = {
     _verbose(name + ' invoked', userId, visitId, count);
     var query = 'SELECT visits.id as visit_id, visits.user_id as user_id, visits.visited_at, * ' +
                 'FROM visits LEFT JOIN user_pages ON visits.user_page_id = user_pages.id ' +
-                'WHERE user_id = $1 ' +
+                'WHERE visits.user_id = $1 ' +
                 'AND visits.visited_at < (SELECT visited_at FROM visits WHERE id = $2) ' +
                 'ORDER BY visits.visited_at DESC LIMIT $3';
     var params = [userId, visitId, count];


### PR DESCRIPTION
@nchapman r?

- add url2png package, update npm shrinkwrap
- add url2png keys to config
- add screenshotUrl to visit, visits, and search items
  - implemented as a view-level transform (not in the DB)
  - this patch introduces some duplication, but I want to separate the "get it working" task from the "make it pretty" refactoring task
- also fix a stray SQL error in `server/models/visits` that I missed with yesterday's giant PR