### PR TITLE
chore(sass): tweaking some styles per scss-lint feedback

### DIFF
--- a/app/styles/.scss-lint.yml
+++ b/app/styles/.scss-lint.yml
@@ -1,0 +1,25 @@
+# Default application configuration that all configurations inherit from.
+
+linters:
+
+  Comment:
+    enabled: false
+
+  HexLength:
+    enabled: true
+    style: long # or 'short'
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+
+  LeadingZero:
+    enabled: true
+    style: include_zero # or 'exclude_zero'
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 4
+
+  Shorthand:
+    enabled: false

--- a/app/styles/modules/_global_header.scss
+++ b/app/styles/modules/_global_header.scss
@@ -10,7 +10,7 @@ header {
 
   h1 {
     @include vertical-align;
-    color: #fff;
+    color: #ffffff;
     font-size: 24px;
     margin: 0;
   }
@@ -27,8 +27,8 @@ header {
 
     input {
       @include hidpi-background-image(icon-search, 16px 16px);
-      background-repeat: no-repeat;
       background-position: top 50% right 10px;
+      background-repeat: no-repeat;
       border: 0;
       border-radius: 6px;
       font-size: 14px;

--- a/app/styles/modules/_row.scss
+++ b/app/styles/modules/_row.scss
@@ -6,8 +6,8 @@
   margin-left: auto;
   margin-right: auto;
   max-width: 740px;
-  padding-right: 20px;
   padding-left: 20px;
+  padding-right: 20px;
   position: relative;
   width: 100%;
 }

--- a/app/styles/modules/_visit.scss
+++ b/app/styles/modules/_visit.scss
@@ -1,8 +1,8 @@
 .visit {
-  background: #fff;
+  background: #ffffff;
   border: 1px solid #dfe1e4;
   // negative spread keeps the shadow from leaking out the sides
-  box-shadow: 0 2px 4px -3px rgba(0,0,0,0.14);
+  box-shadow: 0 2px 4px -3px rgba(0, 0, 0, 0.14);
   overflow: auto;
   padding: 20px;
 
@@ -50,7 +50,7 @@
     }
 
     .description {
-      color: #666;
+      color: #666666;
       font-size: 14px;
     }
 
@@ -67,12 +67,13 @@
     }
   }
 
-  &.medium, &.small {
+  &.medium,
+  &.small {
     .text {
       .provider {
         float: left;
-        margin: 0;
         height: 16px;
+        margin: 0;
 
         .favicon {
           margin-right: 8px;
@@ -95,7 +96,9 @@
     margin-top: 10px;
     padding: 10px 20px;
 
-    .image, .text .provider .name, .text .description {
+    .image,
+    .text .provider .name,
+    .text .description {
       display: none;
     }
 
@@ -115,12 +118,16 @@
   }
 
   // medium or large after a small
-  &.small + &.medium, &.small + &.large {
+  &.small + &.medium,
+  &.small + &.large {
     margin-top: 10px;
   }
 
   // medium or large after one another
-  &.medium + &.large, &.large + &.medium, &.large + &.large, &.medium + &.medium {
+  &.medium + &.large,
+  &.large + &.medium,
+  &.large + &.large,
+  &.medium + &.medium {
     border-top-width: 0;
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lint": "grunt lint",
     "outdated": "npm outdated --depth 0",
     "postinstall": "bower update --config.interactive=false -s",
+    "scss-lint": "scss-lint app/styles || true",
     "shrinkwrap": "npm shrinkwrap --dev && npm run validate-shrinkwrap",
     "start": "grunt serve",
     "test": "echo \"Error: no test specified\"",


### PR DESCRIPTION
For more info on **scss-lint**, see https://github.com/causes/scss-lint.
It requires Ruby, so it doesn't make sense to add this to any "lint" workflows, but it is available as a npm script convenience method (`npm run scss-lint`) if you already have **scss-lint** installed locally.

Current output is this (but I don't agree with merging):

```
app/styles/modules/_visit.scss:115 [W] Merge rule `&.small + &.small` with rule on line 94
```