### PR TITLE
feat(front-end): Adds image proxy via embedly

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -7,8 +7,8 @@ define([
   'use strict';
 
   var config = {
-    oauth: {
-      authEndpoint: '{%= config.get("server.oauth.authEndpoint") %}'
+    embedly: {
+      apiKey: '{%= config.get("embedly.apiKey") %}'
     }
   };
 

--- a/app/scripts/lib/image_proxy.js
+++ b/app/scripts/lib/image_proxy.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'underscore',
+  'jquery',
+  'config'
+], function (_, $, config) {
+  'use strict';
+
+  var EMBEDLY_DISPLAY_ENDPOINT = '//i.embed.ly/1/display';
+
+  // TODO: move this somewhere generic when it's needed in more than one place
+  var IS_RETINA = window.devicePixelRatio >= 1.3;
+
+  var imageProxy = {
+    display: function (url) {
+      return this._buildUrl('', { url: url });
+    },
+
+    crop: function (url, width, height) {
+      return this._buildUrl('/crop', { url: url, width: width, height: height });
+    },
+
+    resize: function (url, width, height, grow) {
+      return this._buildUrl('/resize', { url: url, width: width, height: height, grow: grow });
+    },
+
+    _buildUrl: function (action, options) {
+      // add api key, retinify dimension options, and convert to query params
+      var params = $.param(_.extend({ key: config.embedly.apiKey }, this._retinafyDimensions(options)));
+
+      return EMBEDLY_DISPLAY_ENDPOINT + action + '?' + params;
+    },
+
+    // Increases the size of images to account for retina displays
+    _retinafyDimensions: function (options) {
+      if (IS_RETINA && options.width && options.height) {
+        options.width = options.width * 2;
+        options.height = options.height * 2;
+      }
+
+      return options;
+    }
+  };
+
+  return imageProxy;
+});

--- a/app/scripts/presenters/visit_presenter.js
+++ b/app/scripts/presenters/visit_presenter.js
@@ -3,12 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'underscore'
-], function (_) {
+  'underscore',
+  'lib/image_proxy'
+], function (_, imageProxy) {
   'use strict';
 
   var MINIMUM_IMAGE_ENTROPY = 1.75;
-  var MINIMUM_IMAGE_WIDTH = 270;
+  var IMAGE_DISPLAY_WIDTH = 270;
+  var IMAGE_DISPLAY_HEIGHT = 180;
+
+  // This pattern ignores extracted images from the following URLs
+  // - anything from github (we'll likely have a long list of domains like this)
+  // - any domain without a path
+  // - search results
+  // - anything paged
   var EXTRACTED_IMAGE_DENY_PATTERN = /github.com|(\..{2,3}\/$)|([&?]q=)|([&?]page=\d+)/;
 
   function VisitPresenter (visit) {
@@ -22,7 +30,15 @@ define([
     },
 
     imageUrl: function () {
-      return this.hasValidExtractedImageUrl() ? this.extractedImageUrl : this.screenshot_url;
+      var url = this.hasValidExtractedImageUrl() ? this.extractedImageUrl : this.screenshot_url;
+
+      // it would be smarter to only crop screenshots if we're not in retina, but it's easier
+      // to let the imageProxy just handle it for now.
+      return imageProxy.crop(url, IMAGE_DISPLAY_WIDTH, IMAGE_DISPLAY_HEIGHT);
+    },
+
+    imagePosition: function () {
+      return (this.title.length % 2) ? 'left' : 'right';
     },
 
     isSearchResult: function () {
@@ -40,7 +56,7 @@ define([
     },
 
     hasLargeImage: function () {
-      return this.extractedImageWidth && this.extractedImageWidth >= MINIMUM_IMAGE_WIDTH;
+      return this.extractedImageWidth && this.extractedImageWidth >= IMAGE_DISPLAY_WIDTH;
     },
 
     getInterestingness: function () {

--- a/app/scripts/templates/visits/item.html
+++ b/app/scripts/templates/visits/item.html
@@ -1,4 +1,6 @@
-<div class="image" style="background-image: url({{imageUrl}});"></div>
+<a class="image {{imagePosition}}" href="{{url}}">
+  <img src="{{imageUrl}}" />
+</a>
 <div class="text">
   <div class="provider">
     <img class="favicon" src="{{faviconUrl}}" />

--- a/app/scripts/views/visits/item.js
+++ b/app/scripts/views/visits/item.js
@@ -31,8 +31,6 @@ define([
     afterRender: function () {
       // add size class
       this.$el.addClass(this.presenter.getSizeClassName());
-      // add image position class
-      this.$el.find('.image').addClass(_.sample(['left', 'right']));
     },
 
     destroyModel: function (event) {

--- a/app/styles/modules/_visit.scss
+++ b/app/styles/modules/_visit.scss
@@ -7,12 +7,16 @@
   padding: 20px;
 
   .image {
-    @include two-by-three(270px);
-    background-image: image-url('placeholder.jpg');
-    background-position: center center;
-    background-size: cover;
-    float: right;
-    margin-left: 20px;
+    display: block;
+
+    img {
+      @include two-by-three(270px);
+    }
+
+    &.right {
+      float: right;
+      margin-left: 20px;
+    }
 
     &.left {
       float: left;
@@ -62,7 +66,7 @@
   // Size variations
 
   &.medium {
-    .image {
+    .image img {
       @include two-by-three(160px);
     }
   }


### PR DESCRIPTION
This adds Embedly Display as an image proxy on the front-end. This should fix any mixed content warnings over https and does a little work to serve retina images when appropriate (could be brittle). This also replaces our use of CSS to "crop" images using background cover. This makes images actual img tags instead of scumbag background images.

@6a68 @pdehaan r?