### PR TITLE
feat(front-end): Adds user info data with avatar to header

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'backbone'
+], function (Backbone) {
+  'use strict';
+
+  var User = Backbone.Model.extend({
+    url: function () {
+      return '/v1/profile';
+    }
+  });
+
+  return User;
+});

--- a/app/scripts/templates/global_header/user_info.html
+++ b/app/scripts/templates/global_header/user_info.html
@@ -1,1 +1,14 @@
-<a href="/auth/logout">Sign out</a>
+<img class="avatar" src="{{avatarUrl}}" alt="avatar" />
+
+<nav>
+  <h4>{{email}}</h4>
+  <ul>
+    <li>Manage Firefox Account...</li>
+  </ul>
+  <h4>Chronicle</h4>
+  <ul>
+    <li>Send Feedback</li>
+    <li>Settings</li>
+    <li><a href="/auth/logout">Sign Out of Chronicle</a></li>
+  </ul>
+</nav>

--- a/app/scripts/views/global_header/user_info.js
+++ b/app/scripts/views/global_header/user_info.js
@@ -4,12 +4,21 @@
 
 define([
   'views/base',
-  'stache!templates/global_header/user_info'
-], function (BaseView, UserInfoTemplate) {
+  'stache!templates/global_header/user_info',
+  'models/user'
+], function (BaseView, UserInfoTemplate, User) {
   'use strict';
 
   var UserInfoView = BaseView.extend({
-    template: UserInfoTemplate
+    template: UserInfoTemplate,
+
+    initialize: function () {
+      this.model = new User();
+
+      this.listenTo(this.model, 'change', this.render);
+
+      this.model.fetch();
+    }
   });
 
   return UserInfoView;

--- a/app/styles/modules/_global_header.scss
+++ b/app/styles/modules/_global_header.scss
@@ -11,6 +11,7 @@
   h1 {
     @include vertical-align;
     font-size: 24px;
+    left: 44px;
     margin: 0;
 
     a {
@@ -20,7 +21,29 @@
   }
 
   #user-info {
-    display: none;
+    margin-top: -18px;
+    position: absolute;
+    top: 50%;
+
+    img {
+      border-radius: 50%;
+      height: 36px;
+      width: 36px;
+    }
+
+    nav {
+      background: #fff;
+      border: 1px solid #eee;
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
+      display: none;
+      width: 250px;
+    }
+
+    &:hover {
+      nav {
+        display: block;
+      }
+    }
   }
 
   #search-box {


### PR DESCRIPTION
This should be merged after #265.

* * *

Adds user info box to the header. Looks like this right now:

![screen shot 2015-02-03 at 8 15 24 pm](https://cloud.githubusercontent.com/assets/3095/6035087/7195b1ec-abe1-11e4-891b-8052e5e72c40.png)

Obviously not awesome yet, but ready for @johngruen to style up. We can have that happen in this branch or just merge this and clean up later. Either works for me.

@6a68 @pdehaan r?
