### PR TITLE
feat(front-end): Endless scrolling of visits

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,7 @@
   "globals": {
     "define": false,
     "Promise": true,
-    "window": true
+    "window": true,
+    "document": true
   }
 }

--- a/app/scripts/views/visits/index.js
+++ b/app/scripts/views/visits/index.js
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
+  'underscore',
+  'jquery',
   'views/base',
   'stache!templates/visits/index',
   'collections/visits',
   'views/visits/item'
-], function (BaseView, VisitsIndexTemplate, Visits, VisitsItemView) {
+], function (_, $, BaseView, VisitsIndexTemplate, Visits, VisitsItemView) {
   'use strict';
 
   var VisitsIndexView = BaseView.extend({
@@ -16,15 +18,69 @@ define([
     initialize: function () {
       this.collection = new Visits();
 
-      this.listenTo(this.collection, 'add destroy reset', this.render);
+      this.lastVisitId = null;
+      this.hasMoreVisits = true;
+      this.loadingMoreVisits = false;
+      this.count = 100;
+      this.bottomBufferSize = 750;
+      this.scrollDelay = 50;
 
-      // Fetch visits from the server
-      this.collection.fetch({ reset: true });
+      this.listenTo(this.collection, 'reset', this._renderVisits);
+
+      this._fetch();
     },
 
     afterRender: function () {
+      // check scroll position to see if we should load more visits
+      // don't get crazy though. only check the scroll every this.scrollDelay ms
+      $(window).on('scroll', _.throttle(this._checkScrollPosition.bind(this), this.scrollDelay));
+    },
+
+    beforeDestroy: function () {
+      // stop checking scroll position
+      $(window).off('scroll');
+    },
+
+    // this appends visit items rather than replacing them
+    _renderVisits: function () {
       this.renderCollection(VisitsItemView, '.visits');
-    }
+    },
+
+    _fetch: function () {
+      // let checkScrollPosition know that we're already loading more visits
+      this.loadingMoreVisits = true;
+
+      // prepare the data
+      var data = {
+        count: this.count
+      };
+
+      if (this.lastVisitId) {
+        data.visitId = this.lastVisitId;
+      }
+
+      // fire off the xhr request
+      var xhr = this.collection.fetch({ reset: true, data: data });
+
+      // keep track of the state of things
+      xhr.done(function (data) {
+        this.loadingMoreVisits = false;
+
+        // if the length is less than the count we know there aren't more results
+        this.hasMoreVisits = this.collection.length === this.count;
+        this.lastVisitId = this.collection.last().get('id');
+      }.bind(this));
+    },
+
+    _checkScrollPosition: function () {
+      if (!this.loadingMoreVisits && this.hasMoreVisits && this._getPixelsFromBottom() < this.bottomBufferSize) {
+        this._fetch();
+      }
+    },
+
+    _getPixelsFromBottom: function () {
+      return $(document).height() - $('body').scrollTop() - $(window).height();
+    },
   });
 
   return VisitsIndexView;

--- a/app/scripts/views/visits/item.js
+++ b/app/scripts/views/visits/item.js
@@ -38,6 +38,10 @@ define([
 
       if (window.confirm('Destroy this visit?')) {
         this.model.destroy();
+
+        this.$el.fadeOut(function () {
+          this.remove();
+        }.bind(this));
       }
     }
   });


### PR DESCRIPTION
This should be merged after #265 and #266.

* * *

Here's a take on endless scrolling for visits. I wish it could be simplified further, but it at least does the job for now. It doesn't do anything to keep the back button working so we'll need to fix that in another pass (or target=blank all the things).

@6a68 let me know what you think about this... We can do something simpler if you think that's better.