### PR TITLE
Properly delete visits

### DIFF
--- a/server/db/postgres.js
+++ b/server/db/postgres.js
@@ -42,7 +42,7 @@ var postgres = {
   //
   // query := a prepared query string
   // params := an array of the query params in correct order
-  query: function query(query, params) {
+  query: function query(queryString, params) {
     var _defer = Q.defer();
     var formatted;
     // force promises to eventually resolve
@@ -53,7 +53,7 @@ var postgres = {
         log.trace(err);
         return _defer.reject(err);
       }
-      client.query(query, params, function onQueryResponse(err, results) {
+      client.query(queryString, params, function onQueryResponse(err, results) {
         if (err) {
           log.warn('postgres query failed');
           log.trace(err);


### PR DESCRIPTION
@nchapman @pdehaan r?

TL;DR: visit deletion was busted because of the bug fixed by this patch.

The visit.delete model code was expecting an integer count to be returned by postgres, but `{count: <int>}` was getting returned instead. By the laws of javascript insanity, the code then declared shenanigans, told itself that `count > 0` was definitely not true, and, thus, decided that it was time to delete the user_page, when in fact visits still existed that corresponded to said user_page. That led to a postgres error being thrown and unhandled (because the visits table references the user_pages table as a foreign key, and we do _not_ cascade deletes, in order to avoid accidentally nuking data thanks to exactly this kind of bug!). I suspect/hope the DB connection leakage was happening when that uncaught error nuked the process, since systemctl merrily spun up a new one in response.

I've filed #282 to figure out wtf is going on with our error handling cleanup in the models; the problem may simply be that no graceful shutdown happened, so the db connection was leaked. Still seems highly suboptimal handle uncaught exceptions in this way, since, uh, I expect this won't be the last one that leaks :-\

To be continued, I guess.

I've also fixed a typo that was causing jshint to barf.

The bug fix commit fixes the problems we're seeing in the logs on dev, so (fingers crossed) dev should be solid again after landing this.