### PR TITLE
feat(db): add migrations support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
   - cp config/local.json.travis config/local.json
   # Setup database
   - bin/create_db.sh postgres
+  - bin/migrate.js
   - node bin/create_test_data.js
   # Configure and start xvfb
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ To fetch dependencies and get cooking:
 1. `npm install` and ensure redis, elasticsearch, postgres are all running
 2. As part of the npm install process, the `postinstall` script will install the Bower dependencies for you.
 3. Copy `config/local.json.example` to `config/local.json`, and put your local info in there.
-4. Run `./bin/create_db.sh` to create the database, tables, and indexes
+4. Run `./bin/create_db.sh` to create the database
   - this script currently hard-codes the db user, password, and dbname to 'chronicle' (issue #112)
-5. Run `./bin/create_test_data.js` to create a test user and test data
+5. Run `./bin/migrate.js` to run all the migrations that create the database tables and indexes
+6. Run `./bin/create_test_data.js` to create a test user and test data
   - the test user is defined in the config file
   - the test data is a set of visits created using the URLs in `config/test-urls.js`. Over time we'll experiment with different test data sets, might wind up with a test-urls directory instead.
-6. `npm start`
-7. You're up and running! surf to <http://localhost:8080> :surfer:
+7. `npm start`
+8. You're up and running! surf to <http://localhost:8080> :surfer:
 
 ## Tests
 

--- a/bin/create_db.sh
+++ b/bin/create_db.sh
@@ -18,67 +18,6 @@ psql -c "CREATE USER chronicle WITH PASSWORD 'chronicle';" -U $PSQLUSER
 psql -c "CREATE DATABASE chronicle ENCODING 'UTF-8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';" -U $PSQLUSER
 psql -c 'GRANT ALL PRIVILEGES ON DATABASE chronicle to chronicle;' -U $PSQLUSER
 psql -c 'ALTER SCHEMA public OWNER TO chronicle;' -U $PSQLUSER
-psql -c "CREATE TABLE IF NOT EXISTS users (
-  user_id CHAR(32) PRIMARY KEY,
-  email VARCHAR(255) NOT NULL,
-  oauth_token TEXT,
-  created_at TIMESTAMPTZ(3) NOT NULL,
-  updated_at TIMESTAMPTZ(3) NOT NULL
-);" -d chronicle -U chronicle
-psql -c "CREATE TABLE IF NOT EXISTS user_pages (
-  id UUID PRIMARY KEY,
-  user_id CHAR(32) REFERENCES users(user_id),
-  url VARCHAR(2048) NOT NULL,
-  raw_url VARCHAR(2048) NOT NULL,
-  url_hash CHAR(40) NOT NULL,
-  title TEXT NOT NULL,
-  extracted_at TIMESTAMPTZ(3),
-  extracted_author_name TEXT,
-  extracted_author_url VARCHAR(2048),
-  extracted_cache_age BIGINT,
-  extracted_content TEXT,
-  extracted_description TEXT,
-  extracted_favicon_color TEXT,
-  extracted_favicon_url VARCHAR(2048),
-  extracted_image_caption TEXT,
-  extracted_image_color TEXT,
-  extracted_image_entropy DOUBLE PRECISION,
-  extracted_image_height INTEGER,
-  extracted_image_url VARCHAR(2048),
-  extracted_image_width INTEGER,
-  extracted_language TEXT,
-  extracted_lead TEXT,
-  extracted_media_duration INTEGER,
-  extracted_media_height INTEGER,
-  extracted_media_html TEXT,
-  extracted_media_type TEXT,
-  extracted_media_width INTEGER,
-  extracted_provider_display TEXT,
-  extracted_provider_name TEXT,
-  extracted_provider_url VARCHAR(2048),
-  extracted_published TIMESTAMPTZ(3),
-  extracted_safe BOOLEAN,
-  extracted_title TEXT,
-  extracted_type TEXT,
-  extracted_url VARCHAR(2048),
-  created_at TIMESTAMPTZ(3) NOT NULL,
-  updated_at TIMESTAMPTZ(3) NOT NULL
-);" -d chronicle -U chronicle
-psql -c "CREATE UNIQUE INDEX user_pages_url_hash_user_id
-  ON user_pages (url_hash, user_id);" -d chronicle -U chronicle
-psql -c "CREATE TABLE IF NOT EXISTS visits (
-  id UUID PRIMARY KEY,
-  user_id CHAR(32) NOT NULL REFERENCES users,
-  user_page_id UUID NOT NULL REFERENCES user_pages(id),
-  visited_at TIMESTAMPTZ(3) NOT NULL,
-  updated_at TIMESTAMPTZ(3) NOT NULL
-);" -d chronicle -U chronicle
-# used for visit.get
-psql -c "CREATE UNIQUE INDEX user_id_visited_at_id
-  ON visits (user_id, visited_at, id);" -d chronicle -U chronicle
-# used to check if a user_page should be deleted on visit delete
-psql -c "CREATE UNIQUE INDEX user_id_user_page_id_id
-  ON visits (user_id, user_page_id, id);" -d chronicle -U chronicle
 
 # lest we forget! clean out our elasticsearch index, too
 curl -XDELETE 'http://localhost:9200/chronicle/'

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// use this script to call our pg-patcher wrapper via the command line.
+// TODO add 'next' and 'prev' convenience methods?
+// TODO bring back commander, I guess
+
+var fs = require('fs');
+var log = require('../server/logger')('bin.migrate');
+var migrator = require('../server/db/migrator.js');
+var targetLevel = parseInt(process.argv[2], 10);
+
+// if no args were passed, or if the arg wasn't an integer,
+// then, by default, use the highest defined patch level
+if (isNaN(targetLevel)) {
+  files = fs.readdirSync(__dirname + '/../server/db/migrations');
+  var max = 0;
+  files.forEach(function(file) {
+    // assume files are of the conventional form 'patch-n-m.sql'
+    // we want the largest m in the dir
+    // the regex splits the filename into ['patch', 'n', 'm', 'sql']
+    var curr = file.split(/[-\.]/)[2];
+    if (curr > max) { max = curr; }
+  });
+  targetLevel = max;
+}
+migrator(targetLevel)
+  .done(function onSuccess(resp) {
+    log.info('migration succeeded');
+  }, function onFailure(err) {
+    log.error('migration failed: ' + err);
+  });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,12 +9,12 @@
       "dependencies": {
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@2.x.x",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@^2.2.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -26,7 +26,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -53,32 +53,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -87,7 +87,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -111,12 +111,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -135,63 +135,63 @@
       "dependencies": {
         "bluebird": {
           "version": "2.2.2",
-          "from": "bluebird@~2.2.2",
+          "from": "bluebird@>=2.2.2 <2.3.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.2",
+          "from": "forever-agent@>=0.5.2 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "lodash-node": {
           "version": "2.4.1",
-          "from": "lodash-node@~2.4",
+          "from": "lodash-node@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
         }
       }
@@ -255,8 +255,7 @@
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@>=0.2.4",
-              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+              "from": "traverse@>=0.2.4"
             }
           }
         }
@@ -264,22 +263,22 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@~0.4.5",
+      "from": "grunt@>=0.4.4 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -289,37 +288,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -328,2288 +327,142 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.8",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
-        }
-      }
-    },
-    "grunt-autoprefixer": {
-      "version": "2.1.0",
-      "from": "grunt-autoprefixer@2.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.1.0.tgz",
-      "dependencies": {
-        "autoprefixer-core": {
-          "version": "4.0.2",
-          "from": "autoprefixer-core@^4.0.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-4.0.2.tgz",
-          "dependencies": {
-            "caniuse-db": {
-              "version": "1.0.30000060",
-              "from": "caniuse-db@^1.0.30000030",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000060.tgz"
-            },
-            "postcss": {
-              "version": "3.0.7",
-              "from": "postcss@~3.0.6",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-3.0.7.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.43",
-                  "from": "source-map@~0.1.40",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                    }
-                  }
-                },
-                "js-base64": {
-                  "version": "2.1.7",
-                  "from": "js-base64@~2.1.5",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz"
-                }
-              }
-            }
-          }
-        },
-        "diff": {
-          "version": "1.2.2",
-          "from": "diff@~1.2.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.2.2.tgz"
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-contrib-clean": {
-      "version": "0.6.0",
-      "from": "grunt-contrib-clean@0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@~2.2.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        }
-      }
-    },
-    "grunt-contrib-copy": {
-      "version": "0.7.0",
-      "from": "grunt-contrib-copy@0.7.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.7.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-contrib-jshint": {
-      "version": "0.10.0",
-      "from": "grunt-contrib-jshint@0.10.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
-      "dependencies": {
-        "jshint": {
-          "version": "2.5.11",
-          "from": "jshint@~2.5.0",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
-          "dependencies": {
-            "cli": {
-              "version": "0.6.5",
-              "from": "cli@0.6.x",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@~ 3.2.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "from": "console-browserify@1.1.x",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-              "dependencies": {
-                "date-now": {
-                  "version": "0.1.4",
-                  "from": "date-now@^0.1.4",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-                }
-              }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@0.1.x",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "htmlparser2": {
-              "version": "3.8.2",
-              "from": "htmlparser2@3.8.x",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0",
-                  "from": "domhandler@2.3",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-                },
-                "domutils": {
-                  "version": "1.5.0",
-                  "from": "domutils@1.5",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
-                },
-                "domelementtype": {
-                  "version": "1.1.3",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0",
-                  "from": "entities@1.0",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "minimatch@1.0.x",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@0.3.x",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "strip-json-comments@1.0.x",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "underscore": {
-              "version": "1.6.0",
-              "from": "underscore@1.6.x",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-            }
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        }
-      }
-    },
-    "grunt-contrib-watch": {
-      "version": "0.6.1",
-      "from": "grunt-contrib-watch@0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "dependencies": {
-        "gaze": {
-          "version": "0.5.1",
-          "from": "gaze@~0.5.1",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "globule@~0.1.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.1",
-                  "from": "lodash@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "glob@~3.1.21",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "inherits@1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tiny-lr-fork": {
-          "version": "0.0.5",
-          "from": "tiny-lr-fork@0.0.5",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "qs@~0.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
-            },
-            "faye-websocket": {
-              "version": "0.4.4",
-              "from": "faye-websocket@~0.4.3",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-            },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "noptify@~0.0.3",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "nopt@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@~0.7.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "async@~0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        }
-      }
-    },
-    "grunt-conventional-changelog": {
-      "version": "1.1.0",
-      "from": "grunt-conventional-changelog@1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.1.0.tgz",
-      "dependencies": {
-        "conventional-changelog": {
-          "version": "0.0.6",
-          "from": "conventional-changelog@0.0.6",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
-          "dependencies": {
-            "lodash.assign": {
-              "version": "2.4.1",
-              "from": "lodash.assign@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-              "dependencies": {
-                "lodash._basecreatecallback": {
-                  "version": "2.4.1",
-                  "from": "lodash._basecreatecallback@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash.bind": {
-                      "version": "2.4.1",
-                      "from": "lodash.bind@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._createwrapper": {
-                          "version": "2.4.1",
-                          "from": "lodash._createwrapper@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-                          "dependencies": {
-                            "lodash._basebind": {
-                              "version": "2.4.1",
-                              "from": "lodash._basebind@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._basecreate": {
-                                  "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                                  "dependencies": {
-                                    "lodash._isnative": {
-                                      "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                    },
-                                    "lodash.noop": {
-                                      "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                    }
-                                  }
-                                },
-                                "lodash.isobject": {
-                                  "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash._basecreatewrapper": {
-                              "version": "2.4.1",
-                              "from": "lodash._basecreatewrapper@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-                              "dependencies": {
-                                "lodash._basecreate": {
-                                  "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-                                  "dependencies": {
-                                    "lodash._isnative": {
-                                      "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                                    },
-                                    "lodash.noop": {
-                                      "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
-                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                                    }
-                                  }
-                                },
-                                "lodash.isobject": {
-                                  "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
-                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                                }
-                              }
-                            },
-                            "lodash.isfunction": {
-                              "version": "2.4.1",
-                              "from": "lodash.isfunction@~2.4.1",
-                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-                            }
-                          }
-                        },
-                        "lodash._slice": {
-                          "version": "2.4.1",
-                          "from": "lodash._slice@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.identity": {
-                      "version": "2.4.1",
-                      "from": "lodash.identity@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
-                    },
-                    "lodash._setbinddata": {
-                      "version": "2.4.1",
-                      "from": "lodash._setbinddata@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash.noop": {
-                          "version": "2.4.1",
-                          "from": "lodash.noop@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash.support": {
-                      "version": "2.4.1",
-                      "from": "lodash.support@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash.keys": {
-                  "version": "2.4.1",
-                  "from": "lodash.keys@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                  "dependencies": {
-                    "lodash._isnative": {
-                      "version": "2.4.1",
-                      "from": "lodash._isnative@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                    },
-                    "lodash.isobject": {
-                      "version": "2.4.1",
-                      "from": "lodash.isobject@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "from": "lodash._shimkeys@~2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-                    }
-                  }
-                },
-                "lodash._objecttypes": {
-                  "version": "2.4.1",
-                  "from": "lodash._objecttypes@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                }
-              }
-            },
-            "event-stream": {
-              "version": "3.1.7",
-              "from": "event-stream@~3.1.0",
-              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-              "dependencies": {
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                },
-                "duplexer": {
-                  "version": "0.1.1",
-                  "from": "duplexer@~0.1.1",
-                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-                },
-                "from": {
-                  "version": "0.1.3",
-                  "from": "from@~0",
-                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-                },
-                "map-stream": {
-                  "version": "0.1.0",
-                  "from": "map-stream@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-                },
-                "pause-stream": {
-                  "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
-                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-                },
-                "split": {
-                  "version": "0.2.10",
-                  "from": "split@0.2",
-                  "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
-                },
-                "stream-combiner": {
-                  "version": "0.0.4",
-                  "from": "stream-combiner@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "grunt-copyright": {
-      "version": "0.1.0",
-      "from": "grunt-copyright@0.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
-    },
-    "grunt-git-contributors": {
-      "version": "0.1.5",
-      "from": "grunt-git-contributors@0.1.5",
-      "resolved": "https://registry.npmjs.org/grunt-git-contributors/-/grunt-git-contributors-0.1.5.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "2.2.1",
-          "from": "lodash@~2.2.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
-        }
-      }
-    },
-    "grunt-hapi": {
-      "version": "0.8.1",
-      "from": "grunt-hapi@0.8.1",
-      "resolved": "https://registry.npmjs.org/grunt-hapi/-/grunt-hapi-0.8.1.tgz"
-    },
-    "grunt-jscs": {
-      "version": "1.1.0",
-      "from": "grunt-jscs@1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.1.0.tgz",
-      "dependencies": {
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "jscs": {
-          "version": "1.9.0",
-          "from": "jscs@~1.9.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.9.0.tgz",
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "from": "colors@~1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            },
-            "commander": {
-              "version": "2.5.1",
-              "from": "commander@~2.5.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
-            },
-            "esprima": {
-              "version": "1.2.3",
-              "from": "esprima@~1.2.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz"
-            },
-            "esprima-harmony-jscs": {
-              "version": "1.1.0-dev-harmony",
-              "from": "esprima-harmony-jscs@1.1.0-dev-harmony",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz"
-            },
-            "estraverse": {
-              "version": "1.8.0",
-              "from": "estraverse@~1.8.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.8.0.tgz"
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@0.1.x",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "glob": {
-              "version": "4.0.6",
-              "from": "glob@~4.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.5",
-                  "from": "graceful-fs@^3.0.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "from": "once@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "from": "minimatch@~1.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "strip-json-comments@~1.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "vow-fs": {
-              "version": "0.3.4",
-              "from": "vow-fs@~0.3.1",
-              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
-              "dependencies": {
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@^1.4.2",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "vow-queue": {
-                  "version": "0.4.1",
-                  "from": "vow-queue@^0.4.1",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
-                },
-                "glob": {
-                  "version": "4.3.5",
-                  "from": "glob@^4.3.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.1",
-                      "from": "minimatch@^2.0.1",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "brace-expansion@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "balanced-match@^0.2.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.1",
-                      "from": "once@^1.3.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "xmlbuilder": {
-              "version": "2.4.6",
-              "from": "xmlbuilder@~2.4.0",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.6.tgz",
-              "dependencies": {
-                "lodash-node": {
-                  "version": "2.4.1",
-                  "from": "lodash-node@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "1.2.0",
-              "from": "supports-color@~1.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
-            },
-            "unicode-6.3.0": {
-              "version": "0.1.5",
-              "from": "unicode-6.3.0@~0.1.5",
-              "resolved": "https://registry.npmjs.org/unicode-6.3.0/-/unicode-6.3.0-0.1.5.tgz"
-            },
-            "regenerate": {
-              "version": "1.0.1",
-              "from": "regenerate@~1.0.1",
-              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.0.1.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "vow": {
-          "version": "0.4.8",
-          "from": "vow@~0.4.1",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.8.tgz"
-        }
-      }
-    },
-    "grunt-jsonlint": {
-      "version": "1.0.4",
-      "from": "grunt-jsonlint@1.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
-      "dependencies": {
-        "jsonlint": {
-          "version": "1.6.0",
-          "from": "jsonlint@1.6.0",
-          "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
-          "dependencies": {
-            "nomnom": {
-              "version": "1.8.1",
-              "from": "nomnom@>= 1.5.x",
-              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.6.0",
-                  "from": "underscore@~1.6.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-                },
-                "chalk": {
-                  "version": "0.4.0",
-                  "from": "chalk@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                  "dependencies": {
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "has-color@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "1.0.0",
-                      "from": "ansi-styles@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "0.1.1",
-                      "from": "strip-ansi@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "JSV": {
-              "version": "4.0.2",
-              "from": "JSV@>= 4.0.x",
-              "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-nsp-shrinkwrap": {
-      "version": "0.0.3",
-      "from": "grunt-nsp-shrinkwrap@0.0.3",
-      "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
-      "dependencies": {
-        "cli-color": {
-          "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
-          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-          "dependencies": {
-            "es5-ext": {
-              "version": "0.9.2",
-              "from": "es5-ext@~0.9.2",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
-            },
-            "memoizee": {
-              "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
-              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-              "dependencies": {
-                "event-emitter": {
-                  "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
-                },
-                "next-tick": {
-                  "version": "0.1.0",
-                  "from": "next-tick@0.1.x",
-                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "colors": {
-          "version": "0.6.2",
-          "from": "colors@^0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-        },
-        "grunt": {
-          "version": "0.4.5",
-          "from": "grunt@~0.4.5",
-          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.1.22",
-              "from": "async@~0.1.22",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
-            },
-            "coffee-script": {
-              "version": "1.3.3",
-              "from": "coffee-script@~1.3.3",
-              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
-            },
-            "dateformat": {
-              "version": "1.0.2-1.2.3",
-              "from": "dateformat@1.0.2-1.2.3",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
-            },
-            "eventemitter2": {
-              "version": "0.4.14",
-              "from": "eventemitter2@~0.4.13",
-              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
-            },
-            "findup-sync": {
-              "version": "0.1.3",
-              "from": "findup-sync@~0.1.2",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@~3.2.9",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "3.1.21",
-              "from": "glob@~3.1.21",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                },
-                "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                }
-              }
-            },
-            "hooker": {
-              "version": "0.2.3",
-              "from": "hooker@~0.2.3",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-            },
-            "iconv-lite": {
-              "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
-            },
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@~0.2.12",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                }
-              }
-            },
-            "nopt": {
-              "version": "1.0.10",
-              "from": "nopt@~1.0.10",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.5",
-                  "from": "abbrev@1",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@~2.2.8",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            },
-            "lodash": {
-              "version": "0.9.2",
-              "from": "lodash@~0.9.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
-            },
-            "underscore.string": {
-              "version": "2.2.1",
-              "from": "underscore.string@~2.2.1",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
-            },
-            "which": {
-              "version": "1.0.8",
-              "from": "which@~1.0.5",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
-            },
-            "js-yaml": {
-              "version": "2.0.5",
-              "from": "js-yaml@~2.0.5",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-                  "dependencies": {
-                    "underscore.string": {
-                      "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0",
-                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                }
-              }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@~0.1.1",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "getobject": {
-              "version": "0.1.0",
-              "from": "getobject@~0.1.0",
-              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
-            },
-            "grunt-legacy-util": {
-              "version": "0.2.0",
-              "from": "grunt-legacy-util@~0.2.0",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
-            },
-            "grunt-legacy-log": {
-              "version": "0.1.1",
-              "from": "grunt-legacy-log@~0.1.0",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                },
-                "underscore.string": {
-                  "version": "2.3.3",
-                  "from": "underscore.string@~2.3.3",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-                }
-              }
-            }
-          }
-        },
-        "request": {
-          "version": "2.51.0",
-          "from": "request@^2.34.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-          "dependencies": {
-            "bl": {
-              "version": "0.9.4",
-              "from": "bl@~0.9.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.8.0",
-              "from": "caseless@~0.8.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "from": "forever-agent@~0.5.2",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@~0.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.0",
-                  "from": "async@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.0.8",
-                  "from": "mime-types@~2.0.3",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.8.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.6.0",
-                      "from": "mime-db@~1.6.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.6.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-            },
-            "mime-types": {
-              "version": "1.0.2",
-              "from": "mime-types@~1.0.1",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "qs@~2.3.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-            },
-            "tough-cookie": {
-              "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.5.0",
-              "from": "oauth-sign@~0.5.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-            },
-            "hawk": {
-              "version": "1.1.1",
-              "from": "hawk@1.1.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "0.9.1",
-                  "from": "hoek@0.9.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                },
-                "boom": {
-                  "version": "0.4.2",
-                  "from": "boom@0.4.x",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                },
-                "cryptiles": {
-                  "version": "0.2.2",
-                  "from": "cryptiles@0.2.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                },
-                "sntp": {
-                  "version": "0.2.4",
-                  "from": "sntp@0.2.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@~0.0.4",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@~0.2",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "grunt-requirejs": {
-      "version": "0.4.2",
-      "from": "grunt-requirejs@0.4.2",
-      "resolved": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
-      "dependencies": {
-        "requirejs": {
-          "version": "2.1.15",
-          "from": "requirejs@2.1.x",
-          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.15.tgz"
-        },
-        "cheerio": {
-          "version": "0.13.1",
-          "from": "cheerio@0.13.x",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
-          "dependencies": {
-            "htmlparser2": {
-              "version": "3.4.0",
-              "from": "htmlparser2@~3.4.0",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.2.1",
-                  "from": "domhandler@2.2",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
-                },
-                "domutils": {
-                  "version": "1.3.0",
-                  "from": "domutils@1.3",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
-                },
-                "domelementtype": {
-                  "version": "1.1.3",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "underscore": {
-              "version": "1.5.2",
-              "from": "underscore@~1.5",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
-            },
-            "entities": {
-              "version": "0.5.0",
-              "from": "entities@0.x",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
-            },
-            "CSSselect": {
-              "version": "0.4.1",
-              "from": "CSSselect@~0.4.0",
-              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-              "dependencies": {
-                "CSSwhat": {
-                  "version": "0.4.7",
-                  "from": "CSSwhat@0.4",
-                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
-                },
-                "domutils": {
-                  "version": "1.4.3",
-                  "from": "domutils@1.4",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.1.3",
-                      "from": "domelementtype@1",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "almond": {
-          "version": "0.2.9",
-          "from": "almond@0.2.x",
-          "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
-        },
-        "gzip-js": {
-          "version": "0.3.2",
-          "from": "gzip-js@0.3.x",
-          "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
-          "dependencies": {
-            "crc32": {
-              "version": "0.2.2",
-              "from": "crc32@>= 0.2.2",
-              "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
-            },
-            "deflate-js": {
-              "version": "0.2.3",
-              "from": "deflate-js@>= 0.2.2",
-              "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
-            }
-          }
-        },
-        "q": {
-          "version": "0.8.12",
-          "from": "q@0.8.x",
-          "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
-        }
-      }
-    },
-    "grunt-rev": {
-      "version": "0.1.0",
-      "from": "grunt-rev@0.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
-    },
-    "grunt-sass": {
-      "version": "0.17.0",
-      "from": "grunt-sass@0.17.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.17.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "each-async": {
-          "version": "1.1.1",
-          "from": "each-async@^1.0.0",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-          "dependencies": {
-            "onetime": {
-              "version": "1.0.0",
-              "from": "onetime@^1.0.0",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
-            },
-            "set-immediate-shim": {
-              "version": "1.0.0",
-              "from": "set-immediate-shim@^1.0.0",
-              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
-            }
-          }
-        },
-        "node-sass": {
-          "version": "1.2.3",
-          "from": "node-sass@1.2.3",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-1.2.3.tgz",
-          "dependencies": {
-            "cross-spawn": {
-              "version": "0.2.3",
-              "from": "cross-spawn@^0.2.3",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.3.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "from": "lru-cache@^2.5.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                }
-              }
-            },
-            "gaze": {
-              "version": "0.5.1",
-              "from": "gaze@^0.5.1",
-              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-              "dependencies": {
-                "globule": {
-                  "version": "0.1.0",
-                  "from": "globule@~0.1.0",
-                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "1.0.1",
-                      "from": "lodash@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
-                    },
-                    "glob": {
-                      "version": "3.1.21",
-                      "from": "glob@~3.1.21",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@~1.2.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                        },
-                        "inherits": {
-                          "version": "1.0.0",
-                          "from": "inherits@1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "get-stdin": {
-              "version": "3.0.2",
-              "from": "get-stdin@^3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-            },
-            "meow": {
-              "version": "2.1.0",
-              "from": "meow@^2.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.0.2",
-                      "from": "camelcase@^1.0.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.0",
-                      "from": "map-obj@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
-                    }
-                  }
-                },
-                "indent-string": {
-                  "version": "1.2.0",
-                  "from": "indent-string@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "1.1.1",
-                      "from": "repeating@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.0",
-                          "from": "is-finite@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "1.1.0",
-                  "from": "minimist@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "object-assign@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@^0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "mocha": {
-              "version": "2.1.0",
-              "from": "mocha@^2.0.1",
-              "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.3.0",
-                  "from": "commander@2.3.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-                },
-                "debug": {
-                  "version": "2.0.0",
-                  "from": "debug@2.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "diff": {
-                  "version": "1.0.8",
-                  "from": "diff@1.0.8",
-                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.2",
-                  "from": "escape-string-regexp@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.2.3",
-                  "from": "glob@3.2.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "growl": {
-                  "version": "1.8.1",
-                  "from": "growl@1.8.1",
-                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
-                },
-                "jade": {
-                  "version": "0.26.3",
-                  "from": "jade@0.26.3",
-                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "nan": {
-              "version": "1.6.1",
-              "from": "nan@^1.3.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.1.tgz"
-            },
-            "object-assign": {
-              "version": "1.0.0",
-              "from": "object-assign@^1.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "request": {
-              "version": "2.51.0",
-              "from": "request@^2.48.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "0.9.4",
-                  "from": "bl@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.8.0",
-                  "from": "caseless@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                },
-                "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.9.0",
-                      "from": "async@~0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.0.8",
-                      "from": "mime-types@~2.0.3",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.8.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.6.0",
-                          "from": "mime-db@~1.6.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.6.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
-                },
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                },
-                "tough-cookie": {
-                  "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.5.0",
-                  "from": "oauth-sign@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-                },
-                "hawk": {
-                  "version": "1.1.1",
-                  "from": "hawk@1.1.1",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@0.9.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@^0.3.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "object-assign@^2.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-        }
-      }
-    },
-    "grunt-template": {
-      "version": "0.2.3",
-      "from": "grunt-template@0.2.3",
-      "resolved": "https://registry.npmjs.org/grunt-template/-/grunt-template-0.2.3.tgz"
-    },
-    "grunt-todo": {
-      "version": "0.4.0",
-      "from": "grunt-todo@0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@~0.2",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "grunt-usemin": {
-      "version": "3.0.0",
-      "from": "grunt-usemin@3.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-3.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "debug": {
-          "version": "2.1.1",
-          "from": "debug@~2.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2",
-              "from": "ms@0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@~2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
     },
@@ -2640,17 +493,17 @@
           "dependencies": {
             "joi": {
               "version": "4.9.0",
-              "from": "joi@4.x.x",
+              "from": "joi@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-4.9.0.tgz",
               "dependencies": {
                 "isemail": {
                   "version": "1.1.1",
-                  "from": "isemail@1.x.x",
+                  "from": "isemail@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                 },
                 "moment": {
                   "version": "2.9.0",
-                  "from": "moment@2.x.x",
+                  "from": "moment@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
                 }
               }
@@ -2664,7 +517,7 @@
         },
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@2.x.x",
+          "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "h2o2": {
@@ -2745,7 +598,7 @@
         },
         "qs": {
           "version": "2.3.3",
-          "from": "qs@~2.3.1",
+          "from": "qs@2.3.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "shot": {
@@ -2796,7 +649,7 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.x.x",
+          "from": "topo@1.0.2",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
@@ -2818,419 +671,8 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
-        }
-      }
-    },
-    "intern": {
-      "version": "2.2.2",
-      "from": "intern@2.2.2",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-2.2.2.tgz",
-      "dependencies": {
-        "istanbul": {
-          "version": "0.2.16",
-          "from": "istanbul@0.2.16",
-          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
-          "dependencies": {
-            "esprima": {
-              "version": "1.2.3",
-              "from": "esprima@1.2.x",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.3.tgz"
-            },
-            "escodegen": {
-              "version": "1.3.3",
-              "from": "escodegen@1.3.x",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "1.0.0",
-                  "from": "esutils@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
-                },
-                "estraverse": {
-                  "version": "1.5.1",
-                  "from": "estraverse@~1.5.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
-                },
-                "esprima": {
-                  "version": "1.1.1",
-                  "from": "esprima@~1.1.1",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
-                }
-              }
-            },
-            "handlebars": {
-              "version": "1.3.0",
-              "from": "handlebars@1.3.x",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
-              "dependencies": {
-                "optimist": {
-                  "version": "0.3.7",
-                  "from": "optimist@~0.3",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
-                },
-                "uglify-js": {
-                  "version": "2.3.6",
-                  "from": "uglify-js@~2.3",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@~0.2.6",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "from": "mkdirp@0.5.x",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.1",
-              "from": "nopt@3.x",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
-            },
-            "fileset": {
-              "version": "0.1.5",
-              "from": "fileset@0.1.x",
-              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
-              "dependencies": {
-                "minimatch": {
-                  "version": "0.4.0",
-                  "from": "minimatch@0.x",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@3.x",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.5.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "which": {
-              "version": "1.0.8",
-              "from": "which@1.0.x",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
-            },
-            "async": {
-              "version": "0.9.0",
-              "from": "async@0.9.x",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
-            "abbrev": {
-              "version": "1.0.5",
-              "from": "abbrev@1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@0.0.x",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            },
-            "resolve": {
-              "version": "0.7.4",
-              "from": "resolve@0.7.x",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
-            },
-            "js-yaml": {
-              "version": "3.2.5",
-              "from": "js-yaml@3.x",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.5.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-                  "dependencies": {
-                    "underscore.string": {
-                      "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0",
-                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.1.33",
-          "from": "source-map@0.1.33",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "0.1.0",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-            }
-          }
-        },
-        "dojo": {
-          "version": "2.0.0-dev",
-          "from": "https://github.com/csnover/dojo2-core/archive/ebfa11ba3972944218623a4bd9d124cb8108d70c.tar.gz",
-          "resolved": "https://github.com/csnover/dojo2-core/archive/ebfa11ba3972944218623a4bd9d124cb8108d70c.tar.gz"
-        },
-        "chai": {
-          "version": "1.9.1",
-          "from": "chai@1.9.1",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.1.tgz",
-          "dependencies": {
-            "assertion-error": {
-              "version": "1.0.0",
-              "from": "assertion-error@1.0.0",
-              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
-            },
-            "deep-eql": {
-              "version": "0.1.3",
-              "from": "deep-eql@0.1.3",
-              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-              "dependencies": {
-                "type-detect": {
-                  "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
-                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "leadfoot": {
-          "version": "1.2.1",
-          "from": "leadfoot@1.2.1",
-          "resolved": "https://registry.npmjs.org/leadfoot/-/leadfoot-1.2.1.tgz",
-          "dependencies": {
-            "dojo": {
-              "version": "2.0.0-alpha4",
-              "from": "dojo@2.0.0-alpha4",
-              "resolved": "https://registry.npmjs.org/dojo/-/dojo-2.0.0-alpha4.tgz"
-            }
-          }
-        },
-        "digdug": {
-          "version": "1.2.1",
-          "from": "digdug@1.2.1",
-          "resolved": "https://registry.npmjs.org/digdug/-/digdug-1.2.1.tgz",
-          "dependencies": {
-            "dojo": {
-              "version": "2.0.0-alpha4",
-              "from": "dojo@2.0.0-alpha4",
-              "resolved": "https://registry.npmjs.org/dojo/-/dojo-2.0.0-alpha4.tgz"
-            },
-            "decompress": {
-              "version": "0.2.3",
-              "from": "decompress@0.2.3",
-              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.3.tgz",
-              "dependencies": {
-                "adm-zip": {
-                  "version": "0.4.4",
-                  "from": "adm-zip@^0.4.3",
-                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
-                },
-                "extname": {
-                  "version": "0.1.5",
-                  "from": "extname@^0.1.1",
-                  "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.5.tgz",
-                  "dependencies": {
-                    "ext-list": {
-                      "version": "0.2.0",
-                      "from": "ext-list@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
-                      "dependencies": {
-                        "got": {
-                          "version": "0.2.0",
-                          "from": "got@^0.2.0",
-                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
-                          "dependencies": {
-                            "object-assign": {
-                              "version": "0.3.1",
-                              "from": "object-assign@^0.3.0",
-                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "underscore.string": {
-                      "version": "2.3.3",
-                      "from": "underscore.string@~2.3.3",
-                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-                    }
-                  }
-                },
-                "get-stdin": {
-                  "version": "0.1.0",
-                  "from": "get-stdin@^0.1.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
-                },
-                "map-key": {
-                  "version": "0.1.5",
-                  "from": "map-key@^0.1.1",
-                  "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.5.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "2.4.1",
-                      "from": "lodash@^2.4.1",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-                    },
-                    "underscore.string": {
-                      "version": "2.4.0",
-                      "from": "underscore.string@^2.3.3",
-                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.3.5",
-                  "from": "mkdirp@^0.3.5",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-                },
-                "nopt": {
-                  "version": "2.2.1",
-                  "from": "nopt@^2.2.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@^2.2.2",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                },
-                "stream-combiner": {
-                  "version": "0.0.4",
-                  "from": "stream-combiner@^0.0.4",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-                  "dependencies": {
-                    "duplexer": {
-                      "version": "0.1.1",
-                      "from": "duplexer@~0.1.1",
-                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-                    }
-                  }
-                },
-                "tar": {
-                  "version": "0.1.20",
-                  "from": "tar@^0.1.18",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.7",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
-                    },
-                    "fstream": {
-                      "version": "0.1.31",
-                      "from": "fstream@~0.1.28",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "3.0.5",
-                          "from": "graceful-fs@~3.0.2",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
-                        },
-                        "mkdirp": {
-                          "version": "0.5.0",
-                          "from": "mkdirp@0.5",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                          "dependencies": {
-                            "minimist": {
-                              "version": "0.0.8",
-                              "from": "minimist@0.0.8",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "tempfile": {
-                  "version": "0.1.3",
-                  "from": "tempfile@^0.1.2",
-                  "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
-                  "dependencies": {
-                    "uuid": {
-                      "version": "1.4.2",
-                      "from": "uuid@~1.4.0",
-                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "charm": {
-          "version": "0.2.0",
-          "from": "charm@0.2.0",
-          "resolved": "https://registry.npmjs.org/charm/-/charm-0.2.0.tgz"
-        },
-        "diff": {
-          "version": "1.1.0",
-          "from": "diff@1.1.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.1.0.tgz"
         }
       }
     },
@@ -3241,59 +683,59 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@^2.2.x",
+          "from": "hoek@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.x.x",
+          "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "isemail@1.x.x",
+          "from": "isemail@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
           "version": "2.9.0",
-          "from": "moment@2.x.x",
+          "from": "moment@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
         }
       }
     },
     "jshint": {
       "version": "2.6.0",
-      "from": "jshint@",
+      "from": "jshint@*",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.5",
-          "from": "cli@0.6.x",
+          "from": "cli@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~ 3.2.1",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3304,49 +746,49 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@1.1.x",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@^0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.x",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@3.8.x",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@2.3",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.0",
-              "from": "domutils@1.5",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
             },
             "domelementtype": {
               "version": "1.1.3",
-              "from": "domelementtype@1",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@1.1",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -3356,258 +798,54 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@1.0.x",
+          "from": "minimatch@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "shelljs@0.3.x",
+          "from": "shelljs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@1.0.x",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@1.6.x",
+          "from": "underscore@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        }
-      }
-    },
-    "jshint-stylish": {
-      "version": "1.0.0",
-      "from": "jshint-stylish@1.0.0",
-      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@^0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.1",
-          "from": "log-symbols@^1.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
-        },
-        "string-length": {
-          "version": "1.0.0",
-          "from": "string-length@^1.0.0",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
-          "dependencies": {
-            "strip-ansi": {
-              "version": "2.0.1",
-              "from": "strip-ansi@^2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "1.1.0",
-                  "from": "ansi-regex@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@^0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        }
-      }
-    },
-    "load-grunt-tasks": {
-      "version": "2.0.0",
-      "from": "load-grunt-tasks@2.0.0",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-2.0.0.tgz",
-      "dependencies": {
-        "findup-sync": {
-          "version": "0.2.1",
-          "from": "findup-sync@^0.2.1",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.3.5",
-              "from": "glob@~4.3.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.1",
-                  "from": "minimatch@^2.0.1",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "from": "once@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "multimatch": {
-          "version": "2.0.0",
-          "from": "multimatch@^2.0.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-union": {
-              "version": "1.0.1",
-              "from": "array-union@^1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@^1.0.1",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.1",
-              "from": "minimatch@^2.0.1",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -3618,85 +856,85 @@
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@^1.0.0",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.2",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "strftime@~0.8.2",
+              "from": "strftime@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@^1.2.0",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
@@ -3708,86 +946,103 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@~0.9.x",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         }
       }
     },
     "nodemailer": {
       "version": "1.3.0",
-      "from": "nodemailer@1.3.0",
+      "from": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.3.0.tgz",
       "dependencies": {
         "buildmail": {
           "version": "1.2.0",
-          "from": "buildmail@^1.2.0",
+          "from": "https://registry.npmjs.org/buildmail/-/buildmail-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-1.2.0.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "addressparser@^0.3.1",
+              "from": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
-              "from": "libbase64@^0.1.0",
+              "from": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
             },
             "libqp": {
               "version": "0.1.1",
-              "from": "libqp@^0.1.1",
+              "from": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz"
             }
           }
         },
         "hyperquest": {
           "version": "0.3.0",
-          "from": "hyperquest@^0.3.0",
+          "from": "https://registry.npmjs.org/hyperquest/-/hyperquest-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-0.3.0.tgz",
           "dependencies": {
             "through": {
               "version": "2.2.7",
-              "from": "through@~2.2.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
             },
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@~0.1.0",
+              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             }
           }
         },
         "libmime": {
           "version": "0.1.7",
-          "from": "libmime@^0.1.5",
+          "from": "https://registry.npmjs.org/libmime/-/libmime-0.1.7.tgz",
           "resolved": "https://registry.npmjs.org/libmime/-/libmime-0.1.7.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.6",
-              "from": "iconv-lite@^0.4.4",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.6.tgz",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.6.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
-              "from": "libbase64@^0.1.0",
+              "from": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
             },
             "libqp": {
               "version": "0.1.1",
-              "from": "libqp@^0.1.1",
+              "from": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz"
             }
           }
         },
         "nodemailer-direct-transport": {
           "version": "1.0.0",
-          "from": "nodemailer-direct-transport@^1.0.0",
+          "from": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.0.tgz",
           "dependencies": {
             "smtp-connection": {
               "version": "0.1.7",
-              "from": "smtp-connection@^0.1.5",
+              "from": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-0.1.7.tgz"
+            }
+          }
+        },
+        "nodemailer-smtp-transport": {
+          "version": "0.1.13",
+          "from": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-0.1.13.tgz",
+          "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-0.1.13.tgz",
+          "dependencies": {
+            "nodemailer-wellknown": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.4.tgz"
+            },
+            "smtp-connection": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz"
             }
           }
         }
@@ -3795,17 +1050,17 @@
     },
     "nodemailer-smtp-transport": {
       "version": "0.1.13",
-      "from": "nodemailer-smtp-transport@0.1.13",
+      "from": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-0.1.13.tgz",
       "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-0.1.13.tgz",
       "dependencies": {
         "nodemailer-wellknown": {
           "version": "0.1.4",
-          "from": "nodemailer-wellknown@^0.1.1",
+          "from": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.4.tgz"
         },
         "smtp-connection": {
           "version": "1.1.0",
-          "from": "smtp-connection@^1.0.0",
+          "from": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz"
         }
       }
@@ -3847,12 +1102,12 @@
           "dependencies": {
             "split": {
               "version": "0.3.2",
-              "from": "split@~0.3",
+              "from": "split@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/split/-/split-0.3.2.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@2",
+                  "from": "through@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
@@ -3861,15 +1116,39 @@
         },
         "semver": {
           "version": "4.2.0",
-          "from": "semver@^4.1.0",
+          "from": "semver@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.0.tgz"
         }
       }
     },
-    "precommit-hook": {
-      "version": "1.0.7",
-      "from": "precommit-hook@1.0.7",
-      "resolved": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz"
+    "pg-patcher": {
+      "version": "0.3.0",
+      "from": "pg-patcher@*",
+      "resolved": "https://registry.npmjs.org/pg-patcher/-/pg-patcher-0.3.0.tgz",
+      "dependencies": {
+        "xtend": {
+          "version": "2.1.2",
+          "from": "xtend@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "dependencies": {
+            "object-keys": {
+              "version": "0.4.0",
+              "from": "object-keys@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+            }
+          }
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "argh": {
+          "version": "0.1.3",
+          "from": "argh@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.3.tgz"
+        }
+      }
     },
     "q": {
       "version": "1.1.2",
@@ -3898,17 +1177,15 @@
       "dependencies": {
         "request": {
           "version": "2.16.6",
-          "from": "request@~2.16",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+          "from": "request@>=2.16.0 <2.17.0",
           "dependencies": {
             "form-data": {
               "version": "0.0.10",
-              "from": "form-data@~0.0.3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+              "from": "form-data@>=0.0.3 <0.1.0",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.4",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -3920,81 +1197,70 @@
                 },
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.7",
+                  "from": "async@>=0.2.7 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.7",
+              "from": "mime@>=1.2.7 <1.3.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "hawk": {
               "version": "0.10.2",
-              "from": "hawk@~0.10.2",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+              "from": "hawk@>=0.10.2 <0.11.0",
               "dependencies": {
                 "hoek": {
                   "version": "0.7.6",
-                  "from": "hoek@0.7.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
+                  "from": "hoek@>=0.7.0 <0.8.0"
                 },
                 "boom": {
                   "version": "0.3.8",
-                  "from": "boom@0.3.x",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
+                  "from": "boom@>=0.3.0 <0.4.0"
                 },
                 "cryptiles": {
                   "version": "0.1.3",
-                  "from": "cryptiles@0.1.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
+                  "from": "cryptiles@>=0.1.0 <0.2.0"
                 },
                 "sntp": {
                   "version": "0.1.4",
-                  "from": "sntp@0.1.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
+                  "from": "sntp@>=0.1.0 <0.2.0"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "cookie-jar": {
               "version": "0.2.0",
-              "from": "cookie-jar@~0.2.0",
-              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
+              "from": "cookie-jar@>=0.2.0 <0.3.0"
             },
             "aws-sign": {
               "version": "0.2.0",
-              "from": "aws-sign@~0.2.0",
-              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
+              "from": "aws-sign@>=0.2.0 <0.3.0"
             },
             "oauth-sign": {
               "version": "0.2.0",
-              "from": "oauth-sign@~0.2.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
+              "from": "oauth-sign@>=0.2.0 <0.3.0"
             },
             "forever-agent": {
               "version": "0.2.0",
-              "from": "forever-agent@~0.2.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
+              "from": "forever-agent@>=0.2.0 <0.3.0"
             },
             "tunnel-agent": {
               "version": "0.2.0",
-              "from": "tunnel-agent@~0.2.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
+              "from": "tunnel-agent@>=0.2.0 <0.3.0"
             },
             "json-stringify-safe": {
               "version": "3.0.0",
-              "from": "json-stringify-safe@~3.0.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
+              "from": "json-stringify-safe@>=3.0.0 <3.1.0"
             },
             "qs": {
               "version": "0.5.6",
-              "from": "qs@~0.5.4",
+              "from": "qs@>=0.5.4 <0.6.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             }
           }
@@ -4013,7 +1279,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "nodemailer": "1.3.0",
     "nodemailer-smtp-transport": "0.1.13",
     "pg": "4.1.1",
+    "pg-patcher": "0.3.0",
     "q": "1.1.2",
     "redis": "0.12.1",
     "underscore": "1.7.0",

--- a/server/db/etl/index.js
+++ b/server/db/etl/index.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// TODO: after the db is migrated, push user_pages into elasticsearch, either via
+// direct streaming of data, or by exporting chunks of data into S3, then creating
+// jobs which point at those files. 
+//
+// another approach: the master queries the postgres db to determine how many
+// user pages exist, and batches them using insert date or maybe using the
+// randomness in the uuids.
+//
+// then, the master puts a special query in a job, and the ETL worker, at the time that
+// it runs, asks postgres for that chunk of data, then does the transform, then
+// pushes the results into elasticsearch. This sounds good to me: very parallelizable,
+// doesn't blow out our queue with data, and avoiding data duplication also lets us
+// avoid copying over data that's gone stale between creating + running the job (that
+// is, we don't reindex pages that get deleted between the master querying and the
+// worker inserting into ES).
+//
+// this task is already taking too long, so let's do this in a followup patch.
+//
+// we can use just one worker that pages through the set.
+// we only have one elasticsearch instance, so the one worker is fine, there's no
+// real gain from parallelization.

--- a/server/db/migrations/patch-0-1.sql
+++ b/server/db/migrations/patch-0-1.sql
@@ -1,0 +1,6 @@
+CREATE TABLE property (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+INSERT INTO property(key, value) VALUES('patch', 1);
+

--- a/server/db/migrations/patch-1-0.sql
+++ b/server/db/migrations/patch-1-0.sql
@@ -1,0 +1,1 @@
+DROP TABLE property;

--- a/server/db/migrations/patch-1-2.sql
+++ b/server/db/migrations/patch-1-2.sql
@@ -1,0 +1,66 @@
+-- create the users table
+CREATE TABLE IF NOT EXISTS users (
+  user_id CHAR(32) PRIMARY KEY,
+  email VARCHAR(255) NOT NULL,
+  oauth_token TEXT,
+  created_at TIMESTAMPTZ(3) NOT NULL,
+  updated_at TIMESTAMPTZ(3) NOT NULL
+);
+-- create the user_pages table
+CREATE TABLE IF NOT EXISTS user_pages (
+  id UUID PRIMARY KEY,
+  user_id CHAR(32) REFERENCES users(user_id),
+  url VARCHAR(2048) NOT NULL,
+  raw_url VARCHAR(2048) NOT NULL,
+  url_hash CHAR(40) NOT NULL,
+  title TEXT NOT NULL,
+  extracted_at TIMESTAMPTZ(3),
+  extracted_author_name TEXT,
+  extracted_author_url VARCHAR(2048),
+  extracted_cache_age BIGINT,
+  extracted_content TEXT,
+  extracted_description TEXT,
+  extracted_favicon_color TEXT,
+  extracted_favicon_url VARCHAR(2048),
+  extracted_image_caption TEXT,
+  extracted_image_color TEXT,
+  extracted_image_entropy DOUBLE PRECISION,
+  extracted_image_height INTEGER,
+  extracted_image_url VARCHAR(2048),
+  extracted_image_width INTEGER,
+  extracted_language TEXT,
+  extracted_lead TEXT,
+  extracted_media_duration INTEGER,
+  extracted_media_height INTEGER,
+  extracted_media_html TEXT,
+  extracted_media_type TEXT,
+  extracted_media_width INTEGER,
+  extracted_provider_display TEXT,
+  extracted_provider_name TEXT,
+  extracted_provider_url VARCHAR(2048),
+  extracted_published TIMESTAMPTZ(3),
+  extracted_safe BOOLEAN,
+  extracted_title TEXT,
+  extracted_type TEXT,
+  extracted_url VARCHAR(2048),
+  created_at TIMESTAMPTZ(3) NOT NULL,
+  updated_at TIMESTAMPTZ(3) NOT NULL
+);
+-- create the user_pages index
+CREATE UNIQUE INDEX user_pages_url_hash_user_id
+  ON user_pages (url_hash, user_id);
+-- create the visits table
+CREATE TABLE IF NOT EXISTS visits (
+  id UUID PRIMARY KEY,
+  user_id CHAR(32) NOT NULL REFERENCES users,
+  user_page_id UUID NOT NULL REFERENCES user_pages(id),
+  visited_at TIMESTAMPTZ(3) NOT NULL,
+  updated_at TIMESTAMPTZ(3) NOT NULL
+);
+-- create the visits indexes
+-- used for visit.get
+CREATE UNIQUE INDEX user_id_visited_at_id
+  ON visits (user_id, visited_at, id);
+-- used to check if a user_page should be deleted on visit delete
+CREATE UNIQUE INDEX user_id_user_page_id_id
+  ON visits (user_id, user_page_id, id);

--- a/server/db/migrations/patch-2-1.sql
+++ b/server/db/migrations/patch-2-1.sql
@@ -1,0 +1,6 @@
+-- drop the visits table
+DROP TABLE visits;
+-- drop the user_pages table
+DROP TABLE user_pages;
+-- drop the users table
+DROP TABLE users;

--- a/server/db/migrator.js
+++ b/server/db/migrator.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var fs = require('fs');
+var Joi = require('joi');
+var pg = require('pg');
+var pgpatcher = require('pg-patcher');
+var q = require('q');
+
+var config = require('../config');
+var log = require('../logger')('server.db.migrator');
+var elasticsearch = require('./elasticsearch.js');
+
+var migrator = function (patchLevel) {
+  log.debug('migrator called, patchLevel is ' + patchLevel);
+  var deferred = q.defer();
+  // Joi handles input validation and string -> int coercion for us
+  var result = Joi.validate(patchLevel, Joi.number().integer().required());
+  var level = result.value; 
+  if (result.error) {
+    log.error('migrator failed, arguments failed to validate: ' + result.error);
+    deferred.reject(result.error);
+    return deferred.promise;
+  }
+
+  var dbParams = {
+    user: config.get('db_postgres_user'),
+    password: config.get('db_postgres_password'),
+    host: config.get('db_postgres_host'),
+    port: config.get('db_postgres_port'),
+    database: config.get('db_postgres_database'),
+    ssl: config.get('db_postgres_ssl')
+  };
+
+  pg.connect(dbParams, function onConnect(err, client, done) {
+    if (err) {
+      log.warn('failed to connect to pg');
+      log.trace(err);
+      deferred.reject(err);
+    } else {
+      pgpatcher(client, level, {dir: __dirname + '/migrations'}, function onPatched(err, result) {
+        log.debug('pgpatcher callback fired');
+        // TODO: reindex elasticsearch by extracting user_pages from the migrated DB
+        if (err) {
+          log.error('pgpatcher migration failed: ' + err);
+          done();
+          pg.end();
+          deferred.reject(err);
+        } else {
+          log.info('pgpatcher migration succeeded');
+          done();
+          pg.end();
+          deferred.resolve(result);
+        }
+      });
+    }
+  });
+  return deferred.promise;
+};
+
+module.exports = migrator;


### PR DESCRIPTION
Fixes #92

@nchapman @pdehaan r?

Seems to be working locally for me. If you want to play around with migrations to different levels, we currently have 0, 1, and 2; just do `./bin/migrate.js 0` or whichever int you'd like.

This does not solve the reindexing problem for elasticsearch, that will be in followup issue #291.