### PR TITLE
Issue 291 reindex on migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To fetch dependencies and get cooking:
 3. Copy `config/local.json.example` to `config/local.json`, and put your local info in there.
 4. Run `./bin/create_db.sh` to create the database
   - this script currently hard-codes the db user, password, and dbname to 'chronicle' (issue #112)
-5. Run `./bin/migrate.js` to run all the migrations that create the database tables and indexes
+5. Run `./bin/migrate.js` to run all the migrations that create the database tables and indexes. (This script also reindexes elasticsearch, but on the first pass, you don't have data in postgres to copy over.)
 6. Run `./bin/create_test_data.js` to create a test user and test data
   - the test user is defined in the config file
   - the test data is a set of visits created using the URLs in `config/test-urls.js`. Over time we'll experiment with different test data sets, might wind up with a test-urls directory instead.

--- a/server/config.js
+++ b/server/config.js
@@ -107,6 +107,26 @@ var conf = convict({
     env: 'REDIS_DATABASE',
     format: 'int'
   },
+  db_reindex_timeout: {
+    doc: 'Timeout for an individual step of the reindexing job.',
+    format: 'int',
+    default: 30000
+  },
+  db_reindex_batchSize: {
+    doc: 'Batch size for elasticsearch reindexing',
+    default: 100,
+    format: 'int'
+  },
+  db_reindex_maxRetries: {
+    doc: 'Number of times to retry an individual reindexing step before giving up completely',
+    default: 5,
+    format: 'int'
+  },
+  db_reindex_retryWait: {
+    doc: 'Base wait period before retrying after a failure. There is a linear multiplier in the code.',
+    default: 10000,
+    format: 'int'
+  },
   // TODO put these under a 'services' namespace
   embedly_enabled: {
     doc: 'Disable embedly for running on travis.',

--- a/server/db/elasticsearch.js
+++ b/server/db/elasticsearch.js
@@ -4,11 +4,16 @@
 
 'use strict';
 
+// TODO we should probably remove the elasticsearch-js library, it is garbage
 var es = require('elasticsearch');
 var Q = require('q');
 
 var config = require('../config');
 var log = require('../logger')('server.db.elasticsearch');
+var logLevel = config.get('server_log_level');
+
+// elasticsearch doesn't have a verbose level, so shift to debug as needed
+if (logLevel === 'verbose') { logLevel = 'debug'; }
 
 // >:-(
 // https://github.com/elasticsearch/elasticsearch-js/issues/33
@@ -16,24 +21,28 @@ var esParamsFactory = function() {
   return {
     host: {
       host: config.get('db_elasticsearch_host'),
-      post: config.get('db_elasticsearch_port'),
-      log: 'verbose'
-    }
+      port: config.get('db_elasticsearch_port')
+    },
+    log: logLevel,
+    // doesn't seem to actually disable keepalives, just allows client to
+    // close when http times out (15 sec). if not disabled, the process
+    // will hang forever and have to be manually killed!
+    keepAlive: false
   };
 };
 
-// TODO figure out connection pooling and do it in here ^_^
+var esClient = new es.Client(esParamsFactory());
+var timeout = config.get('db_elasticsearch_queryTimeout');
+
 var elasticsearch = {
-  timeout: config.get('db_elasticsearch_queryTimeout'),
   // query elasticsearch; returns a promise
   //
   // queryType := es client API method, for example, 'create'
   // params := es query DSL object
   query: function query(queryType, params) {
-    var esClient = new es.Client(esParamsFactory());
     // force promises to eventually resolve
     // NOTE: I checked, elasticsearch uses bluebird, which supports Promise.timeout ^_^
-    return esClient[queryType](params).timeout(elasticsearch.timeout, 'elasticsearch timed out');
+    return esClient[queryType](params).timeout(timeout, 'elasticsearch timed out');
   }
 };
 

--- a/server/db/migrations/patch-1-2.sql
+++ b/server/db/migrations/patch-1-2.sql
@@ -59,8 +59,8 @@ CREATE TABLE IF NOT EXISTS visits (
 );
 -- create the visits indexes
 -- used for visit.get
-CREATE UNIQUE INDEX user_id_visited_at_id
+CREATE UNIQUE INDEX visits_user_id_visited_at_id
   ON visits (user_id, visited_at, id);
 -- used to check if a user_page should be deleted on visit delete
-CREATE UNIQUE INDEX user_id_user_page_id_id
+CREATE UNIQUE INDEX visits_user_id_user_page_id_id
   ON visits (user_id, user_page_id, id);

--- a/server/db/migrations/patch-2-3.sql
+++ b/server/db/migrations/patch-2-3.sql
@@ -1,0 +1,2 @@
+-- used for batch reindexing based on creation time
+CREATE INDEX user_pages_created_at ON user_pages (created_at);

--- a/server/db/migrations/patch-3-2.sql
+++ b/server/db/migrations/patch-3-2.sql
@@ -1,0 +1,1 @@
+DROP INDEX user_pages_created_at;

--- a/server/db/reindex.js
+++ b/server/db/reindex.js
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var q = require('q');
+var config = require('../config');
+var log = require('../logger')('server.db.reindex');
+var postgres = require('./postgres');
+var elasticsearch = require('./elasticsearch');
+var isRunning = false;
+
+// keys on the params object:
+//  done - a callback to be fired when all done, or on unrecoverable error
+//  startTime - time that reindexing started, used to ensure linear traversal through
+//              user_pages in postgres
+//  offset: number of records processed, used as postgres query OFFSET
+//  stepSize: number of records processed per iteration, used as postgres LIMIT
+//            (db_reindex_batchSize config value)
+//  errorCount: number of sequential errors encountered; after a certain number, we
+//              give up (db_reindex_maxRetries config value)
+//  retryWait: base number of seconds to wait before post-error retry; multiplied by
+//             the error count for linear backoff (db_reindex_retryWait config value)
+//  maxRetries: number of sequential errors allowed before we bail
+//              (db_reindex_maxRetries config value)
+var job = function(params) {
+  var pgResultCount, esResultCount;
+
+  var extract_ = function() {
+    var query = 'SELECT * FROM user_pages WHERE created_at < $1 ' +
+                'ORDER BY created_at OFFSET $2 LIMIT $3';
+    return postgres.query(query, [params.startTime, params.offset, params.stepSize])
+      .fail(function(err) {
+        log.warn(err);
+        throw new Error('postgres extraction failed');
+      });
+  };
+
+  var transform_ = function(results) {
+    // edge case: if the number of postgres records is divisible by stepSize,
+    // then the count will be 0 in the last iteration. unfortunately we have
+    // to propagate this down the success handlers. TODO: find a better way
+    results = results || [];
+    // edge case: if there was 1 result, postgres returns a singleton object, we want an array
+    if (!('length' in results)) {
+      results = [results];
+    }
+    log.debug('results.length is ' + results.length);
+    pgResultCount = results.length;
+    var esParams = [];
+    results.forEach(function(result) {
+      // bulk API is a little funny, two parts:
+      // 1. action description
+      esParams.push({ index: { _index: 'chronicle', _type: 'userPages', _id: result.id } });
+      // 2. document to index
+      esParams.push(result);
+    });
+    log.debug('esParams.length is ' + esParams.length);
+    return q(esParams);
+  };
+
+  var load_ = function(data) {
+    log.debug('inside load_, data.length is ' + data.length);
+    if (!data.length) {
+      // this is the edge case where no results came back - we're done
+      return q(0);
+    }
+    return elasticsearch.query('bulk', { body: data })
+      .done(function(esResponse) {
+        esResultCount = esResponse.items.length;
+        log.debug('esResultCount is ' + esResultCount + ', pgResultCount is ' + pgResultCount);
+        if (esResultCount === pgResultCount) {
+          log.debug('esResultCount is ' + esResultCount);
+          return q(esResultCount);
+        } else {
+          // something went wrong, try again
+          throw new Error('result counts did not match');
+        }
+      }, function(err) {
+        log.warn(err);
+        throw new Error('elasticsearch insertion failed');
+      });
+  };
+
+  q().timeout(config.get('db_reindex_timeout'))
+    .then(extract_)
+    .then(transform_)
+    .then(load_)
+    .done(function(result) {
+      log.debug('completed an iteration');
+      log.debug('result count from last iteration is ' + result);
+      // if the number of results was smaller than the stepSize, then that
+      // was the last step; we're done.
+      if (result < params.stepSize) {
+        isRunning = false;
+        log.debug('last iteration processed ' + result + ' records, step size is ' + params.stepSize);
+        log.info('reindexing complete');
+        return params.done();
+      }
+      // else, update the offset counter, then call this function again.
+      params.offset += params.stepSize;
+      params.errorCount = 0;
+      log.debug('reindexing another chunk, updated offset is now ' + params.offset);
+      job(params);
+    }, function(err) {
+      log.warn(err);
+      params.errorCount += 1;
+      if (params.errorCount > params.maxRetries) {
+        isRunning = false;
+        var msg = 'reindexing failed too many times, aborting';
+        log.critical(msg);
+        return params.done(msg);
+      }
+      setTimeout(function() { job(params); }, params.errorCount * params.retryWait);
+    });
+};
+
+function start(cb) {
+  log.info('starting elasticsearch reindex process');
+  if (isRunning) {
+    var msg = 'reindex is already running';
+    log.critical(msg);
+    return cb(msg);
+  }
+  isRunning = true;
+  elasticsearch.query('deleteByQuery', {
+    index: 'chronicle',
+    type: 'userPages',
+    body: { query: { match_all: {} } }
+  })
+  .done(function() {
+    log.info('reindex job deleted userPages, now starting to reindex');
+    job({
+      done: cb,
+      startTime: new Date().toJSON(),
+      offset: 0,
+      errorCount: 0,
+      stepSize: config.get('db_reindex_batchSize'),
+      maxRetries: config.get('db_reindex_maxRetries'),
+      retryWait: config.get('db_reindex_retryWait')
+    });
+  }, function(err) {
+    var msg = 'reindex job could not delete userPages, aborting';
+    log.critical(err);
+    return cb(msg);
+  });
+}
+
+module.exports = {
+  start: start,
+  isRunning: function() { return isRunning; }
+};

--- a/server/embedly.js
+++ b/server/embedly.js
@@ -17,6 +17,13 @@ var logFactory = require('./logger');
 var log = logFactory('server.services.embedly');
 var npmLog = logFactory('server.services.embedly.vendor');
 
+// returns hex number without the prepended '#'
+// accepts an array with [r, g, b] in specified order
+var _rgbToHex = function(color) {
+  /*jshint bitwise: false */
+  return ((1 << 24) + (color[0] << 16) + (color[1] << 8) + color[2]).toString(16).slice(1);
+};
+
 module.exports = {
   extract: function extract(url, cb) {
     log.debug('embedly.extract called');
@@ -32,6 +39,7 @@ module.exports = {
     new Embedly({key: apiKey, logger: npmLog}, function(err, api) {
       if (err) { return cb(err); }
       api.extract({url:url}, function(err, data) {
+        var r, g, b;
         log.verbose('embedly.extract callback for url ' + url + ' returned data ' + JSON.stringify(data));
         if (err) { return cb(err); }
         var d = data && data[0];
@@ -81,7 +89,8 @@ module.exports = {
 
         if (d.favicon_colors && d.favicon_colors.length) {
           // this is an array of r,g,b values, eg [181, 187, 194]
-          out.extractedFaviconColor = d.favicon_colors[0].color;
+          // convert it to a hex color
+          out.extractedFaviconColor = _rgbToHex(d.favicon_colors[0].color);
         }
 
         if (d.images && d.images.length) {
@@ -92,7 +101,7 @@ module.exports = {
           out.extractedImageCaption = d.images[0].caption;
           // another array of rgb values
           if (d.images.colors) {
-            out.extractedImageColor = d.images[0].colors[0].color;
+            out.extractedImageColor = _rgbToHex(d.images[0].colors[0].color);
           }
         }
 


### PR DESCRIPTION
@nchapman @pdehaan r?

Since we're only using one worker for now, I didn't bother integrating this into the work queue. However, I did make sure all the job variables were passed into the "worker" as the params object. Should be pretty straightforward to move this into the queue later.

Also made a couple of minor adjustments to the DB, should be self-explanatory, except the rgb -> hex conversion was added because I saw elasticsearch complaining, and might have some impact on the front-end code (if we're using the favicon colors). Note that they're stored without the leading '#'.