### PR TITLE
bug(search): include description when searching

### DIFF
--- a/server/models/visits.js
+++ b/server/models/visits.js
@@ -83,6 +83,7 @@ var visits = {
                 fields: [
                   'extractedTitle',
                   'extractedContent',
+                  'extractedDescription',
                   'extractedProviderDisplay',
                   'extractedProviderName',
                   'extractedAuthorName'


### PR DESCRIPTION
Fixes #324 

@nchapman mind taking a look? Seems to be working for me:

![screenshot 2015-02-12 14 27 32](https://cloud.githubusercontent.com/assets/96396/6178503/661f02a2-b2c4-11e4-9b9a-1fc1fc613323.png)
