### PR TITLE
feat(front-end): Adds welcome with add-on installation

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -26,6 +26,7 @@
         <p>&copy; 2015 &bull; <a href="http://mozilla.org/" target="_blank">Mozilla</a></p>
       </div>
     </footer>
+    <div id="modal"></div>
     <!-- build:js scripts/compiled.js -->
     <script data-main="scripts/main" src="bower_components/requirejs/require.js"></script>
     <!-- endbuild -->

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -9,6 +9,11 @@ define([
   var config = {
     embedly: {
       apiKey: '{%= config.get("embedly_apiKey") %}'
+    },
+    addon: {
+      firefox: {
+        url: '{%= config.get("addon_firefox_url") %}'
+      }
     }
   };
 

--- a/app/scripts/lib/modal_manager.js
+++ b/app/scripts/lib/modal_manager.js
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'underscore',
+  'jquery',
+  'velocity',
+  'velocityui'
+], function (_, $) {
+  'use strict';
+
+  function ModalManager () {
+    this._viewStates = [];
+    this.$modal = $('#modal');
+
+    // Handle default button actions
+    this.$modal.on('click', 'a.close', this.close.bind(this));
+    this.$modal.on('click', 'a.back', this.pop.bind(this));
+  }
+
+  _.extend(ModalManager.prototype, {
+    /**
+    * Opens the modal. This is a specialized version of `push` that cleans up previous views.
+    *
+    * @method open
+    * @param {Backbone.View} view Backbone view to be rendered and placed in the modal
+    * @param {Object} options Behavioral options for the modal
+    * @param {VelocityObject} options.effect Animation effect to use when opening the modal
+    * @param {Boolean} options.fullScreen Make the modal full screen
+    */
+    open: function (view, options) {
+      this._destroyViews();
+
+      this.push(view, options);
+    },
+
+    /**
+    * Pushes a view onto the modal view stack.
+    *
+    * @method push
+    * @param {Backbone.View} view Backbone view to be rendered and placed in the modal
+    * @param {Object} options Behavioral options for the modal
+    * @param {VelocityObject} options.effect Animation effect to use when opening the modal
+    * @param {Boolean} options.fullScreen Make the modal full screen
+    */
+    push: function (view, options) {
+      this._viewStates.push({ view: view, options: (options || {}) });
+
+      this._show();
+    },
+
+
+    /**
+    * Pops the top most view off the view stack.
+    *
+    * @method pop
+    */
+    pop: function () {
+      var viewState = this._viewStates.pop();
+
+      if (viewState) {
+        viewState.view.destroy();
+      }
+
+      if (this._viewStates.length > 0) {
+        this._show();
+      } else {
+        this._hide();
+      }
+    },
+
+    /**
+    * Closes the modal.
+    *
+    * @method close
+    * @param {Object} options Options for closing the modal
+    * @param {VelocityObject} options.effect Animation effect to use when closing the modal
+    */
+    close: function (options) {
+      this._destroyViews();
+      this._hide(options);
+    },
+
+
+    /**
+    * Cleans up all the views in the stack and empties the `_viewStates`.
+    *
+    * @private
+    * @method _destroyViews
+    */
+    _destroyViews: function () {
+      _.each(this.viewStates, function (viewState) {
+        viewState.view.destroy();
+      });
+
+      this._viewStates = [];
+    },
+
+    /**
+    * Shows the last view in the stack.
+    *
+    * @private
+    * @method _show
+    */
+    _show: function () {
+      var viewState = _.last(this._viewStates);
+
+      viewState.view.render();
+
+      // Force delegate events to fix an issue where restoring a previous view breaks event bindings
+      viewState.view.delegateEvents();
+
+      // TODO: Add fancy positioning: likely in the middle of the screen. We're only supporting
+      // full screen right now, so it can come later.
+
+      // Add full-screen class if the full screen option is enabled
+      if (viewState.options.fullScreen) {
+        this.$modal.addClass('full-screen');
+      } else {
+        this.$modal.removeClass('full-screen');
+      }
+
+      // Replace modal contents
+      this.$modal.html(viewState.view.el);
+
+      // Animate if an effect is provided
+      if (viewState.options.effect) {
+        this.$modal.velocity(viewState.options.effect);
+      } else {
+        this.$modal.show();
+      }
+    },
+
+    /**
+    * Hides the modal.
+    *
+    * @private
+    * @method _hide
+    * @param {Object} options Options for closing the modal
+    * @param {VelocityObject} options.effect Animation effect to use when closing the modal
+    */
+    _hide: function (options) {
+      options = options || {};
+
+      // Animate if an effect is provided
+      if (options.effect) {
+        this.$modal.velocity(options.effect, function () {
+          // Reset styles and hide
+          $(this).removeAttr('style').hide();
+        });
+      } else {
+        this.$modal.hide();
+      }
+    }
+  });
+
+  // Return a singleton
+  return new ModalManager();
+});

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -12,7 +12,9 @@ require.config({
     text: '../bower_components/requirejs-text/text',
     mustache: '../bower_components/mustache/mustache',
     stache: '../bower_components/requirejs-mustache/stache',
-    moment: '../bower_components/moment/moment'
+    moment: '../bower_components/moment/moment',
+    velocity: '../bower_components/velocity/velocity',
+    velocityui: '../bower_components/velocity/velocity.ui'
   },
   shim: {
     underscore: {

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -5,16 +5,19 @@
 define([
   'jquery',
   'backbone',
+  'lib/modal_manager',
   'views/global_header/global_header',
   'views/visits/index',
-  'views/search/index'
-], function ($, Backbone, GlobalHeaderView, VisitsIndexView, SearchIndexView) {
+  'views/search/index',
+  'views/welcome'
+], function ($, Backbone, modalManager, GlobalHeaderView, VisitsIndexView, SearchIndexView, WelcomeView) {
   'use strict';
 
   var Router = Backbone.Router.extend({
     routes: {
       '': 'showIndex',
-      'search/(:query)': 'showSearchIndex'
+      'search/(:query)': 'showSearchIndex',
+      'welcome': 'showWelcome'
     },
 
     initialize: function () {
@@ -35,6 +38,13 @@ define([
 
     showSearchIndex: function (query) {
       this.setStage(new SearchIndexView(query));
+    },
+
+    showWelcome: function () {
+      modalManager.open(new WelcomeView(), { fullScreen: true });
+
+      // Setup the index view underneath the modal
+      this.showIndex();
     },
 
     setStage: function (view) {

--- a/app/scripts/templates/welcome.html
+++ b/app/scripts/templates/welcome.html
@@ -1,0 +1,17 @@
+<h1>Welcome y'all</h1>
+
+{{#supportedBrowser}}
+<div id="install-container">
+  <p>Some details about the add-on</p>
+  <button class="install">Install the add-on</button>
+</div>
+<div id="continue-container" class="hidden">
+  <p>Go ahead and install that add-on and then continue to awesomeness.</p>
+  <button class="continue">Bring it on</button>
+</div>
+{{/supportedBrowser}}
+
+{{^supportedBrowser}}
+  <p>Sorry, there isn't currently an add-on for your browser.</p>
+  <button class="continue">Continue</button>
+{{/supportedBrowser}}

--- a/app/scripts/views/welcome.js
+++ b/app/scripts/views/welcome.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'underscore',
+  'backbone',
+  'jquery',
+  'views/base',
+  'stache!templates/welcome',
+  'lib/modal_manager',
+  'config'
+], function (_, Backbone, $, BaseView, WelcomeTemplate, modalManager, config) {
+  'use strict';
+
+  var WelcomeView = BaseView.extend({
+    className: 'welcome',
+    template: WelcomeTemplate,
+
+    events: {
+      'click button.install': 'install',
+      'click button.continue': 'continue'
+    },
+
+    install: function (event) {
+      event.preventDefault();
+
+      $.Velocity.RunSequence([
+        { e: this.$('#install-container'), p: 'transition.fadeOut' },
+        { e: this.$('#continue-container'), p: 'transition.fadeIn' }
+      ]);
+
+      // Trigger add-on installation
+      window.location = config.addon.firefox.url;
+    },
+
+    continue: function (event) {
+      event.preventDefault();
+
+      // Set the URL to the root but don't trigger since the view is already in place
+      Backbone.history.navigate('/');
+
+      modalManager.close({ effect: 'transition.fadeOut' });
+    },
+
+    getContext: function () {
+      return {
+        supportedBrowser: /firefox/i.test(window.navigator.userAgent)
+      };
+    }
+  });
+
+  return WelcomeView;
+});

--- a/app/styles/_modules.scss
+++ b/app/styles/_modules.scss
@@ -5,3 +5,5 @@
 @import 'modules/user_page';
 @import 'modules/actions';
 @import 'modules/search_result';
+@import 'modules/welcome';
+@import 'modules/modal';

--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -1,25 +1,25 @@
-.is-hidden {
+.hidden {
   display: none;
 }
 
-.is-succcess {
+.succcess {
   color: $success;
 }
 
-.is-warning {
+.warning {
   color: $warning;
 }
 
-.is-triggered {
+.triggered {
   background: linear-gradient(to bottom, #060606 0%, #2d2d2d 100%);
 }
 
 
-@mixin is-border-state-machine($border-width, $base-color, $engaged-color) {
+@mixin border-state-machine($border-width, $base-color, $engaged-color) {
   border: $border-width solid $base-color;
   transition: all $fast;
 
-  &:hover, 
+  &:hover,
   &:focus {
     border-color: $engaged-color;
   }

--- a/app/styles/modules/_global_header.scss
+++ b/app/styles/modules/_global_header.scss
@@ -2,7 +2,7 @@
   @include color-scheme($white, $middle-grey);
   position: fixed;
   top: 0;
-  z-index: 100;
+  z-index: 10;
 
   .row-inner {
     height: $double-grid;
@@ -32,11 +32,11 @@
     form {
       flex: 1;
     }
-    
+
     input {
       @include hidpi-background-image(icon-search, 16px 16px);
       @include color-scheme($middle-grey, $white);
-      @include is-border-state-machine(2px, $middle-grey, $dark-grey);
+      @include border-state-machine(2px, $middle-grey, $dark-grey);
       background-position: top 50% right 12px;
       background-repeat: no-repeat;
       border-radius: $double-radius;

--- a/app/styles/modules/_modal.scss
+++ b/app/styles/modules/_modal.scss
@@ -1,0 +1,12 @@
+#modal {
+  background: $white;
+  left: 0;
+  position: absolute;
+  top: 0;
+  z-index: 20;
+
+  &.full-screen {
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/app/styles/modules/_welcome.scss
+++ b/app/styles/modules/_welcome.scss
@@ -1,0 +1,2 @@
+#modal .welcome {
+}

--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "requirejs-text": "~2.0.12",
     "requirejs": "~2.1.15",
     "mustache": "~0.8.2",
-    "moment": "~2.9.0"
+    "moment": "~2.9.0",
+    "velocity": "~1.2.1"
   }
 }

--- a/config/local.json.example
+++ b/config/local.json.example
@@ -40,5 +40,6 @@
   "server_oauth_authEndpoint": "https://oauth-latest.dev.lcip.org/v1/authorization",
   "server_oauth_tokenEndpoint": "https://oauth-latest.dev.lcip.org/v1/token",
   "server_oauth_profileEndpoint": "https://latest.dev.lcip.org/profile/v1/profile",
-  "testUser_enabled": true
+  "testUser_enabled": true,
+  "addon_firefox_url": ""
 }

--- a/server/config.js
+++ b/server/config.js
@@ -287,6 +287,12 @@ var conf = convict({
     doc: 'Whether to automatically reset the ttl on cookies.',
     default: true,
     format: Boolean
+  },
+  addon_firefox_url: {
+    doc: 'Firefox Add-on URL',
+    format: String,
+    default: 'http://your-add-on-url-goes-here/',
+    env: 'ADDON_FIREFOX_URL'
   }
 });
 

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -44,7 +44,12 @@ var authController = {
       session.expiresAt = new Date(new Date().getTime() + duration);
     }
     request.auth.session.set(session);
-    reply.redirect('/');
+    if (request.auth.credentials.profile.isNewUser) {
+      reply.redirect('/#welcome');
+    } else {
+      reply.redirect('/');
+    }
+
   }
 };
 


### PR DESCRIPTION
This adds the authenticated portion of the onboarding flow at `/#welcome`. If you're a new user to Chronicle, you'll be directed here after your account is created. This is purposely unstyled and therefore ready for @johngruen to turn it into something much better. It doesn't do a whole lot for now, but will at least help you get the add-on installed in Firefox.

Fixes #247.

@6a68 @johngruen r?