### PR TITLE
chore(build): replace precommit-hook with husky for auto linting

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -160,7 +160,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -172,7 +172,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -387,7 +387,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -693,7 +693,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -705,7 +705,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -1279,7 +1279,7 @@
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.2",
+              "from": "exit@0.1.x",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
@@ -1999,7 +1999,7 @@
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@2.0.4",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
@@ -2228,7 +2228,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@^0.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -2240,7 +2240,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@^0.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -2851,7 +2851,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2863,7 +2863,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2909,7 +2909,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2921,7 +2921,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3116,7 +3116,7 @@
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.0.2",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "vision": {
@@ -3142,6 +3142,11 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
+    },
+    "husky": {
+      "version": "0.6.2",
+      "from": "husky@0.6.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.6.2.tgz"
     },
     "intern": {
       "version": "2.2.2",
@@ -3561,7 +3566,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@^2.2.x",
+          "from": "hoek@2.x.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
@@ -3578,166 +3583,6 @@
           "version": "2.9.0",
           "from": "moment@2.x.x",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
-        }
-      }
-    },
-    "jshint": {
-      "version": "2.6.0",
-      "from": "jshint@",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
-      "dependencies": {
-        "cli": {
-          "version": "0.6.5",
-          "from": "cli@0.6.x",
-          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "3.2.11",
-              "from": "glob@~ 3.2.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "from": "minimatch@0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "console-browserify@1.1.x",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "dependencies": {
-            "date-now": {
-              "version": "0.1.4",
-              "from": "date-now@^0.1.4",
-              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-            }
-          }
-        },
-        "exit": {
-          "version": "0.1.2",
-          "from": "exit@0.1.x",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-        },
-        "htmlparser2": {
-          "version": "3.8.2",
-          "from": "htmlparser2@3.8.x",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-          "dependencies": {
-            "domhandler": {
-              "version": "2.3.0",
-              "from": "domhandler@2.3",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-            },
-            "domutils": {
-              "version": "1.5.1",
-              "from": "domutils@1.5",
-              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-              "dependencies": {
-                "dom-serializer": {
-                  "version": "0.1.0",
-                  "from": "dom-serializer@0",
-                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                  "dependencies": {
-                    "entities": {
-                      "version": "1.1.1",
-                      "from": "entities@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "domelementtype": {
-              "version": "1.1.3",
-              "from": "domelementtype@1",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@1.1",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.0.0",
-              "from": "entities@1.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "1.0.0",
-          "from": "minimatch@1.0.x",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@2",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-            },
-            "sigmund": {
-              "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.3.0",
-          "from": "shelljs@0.3.x",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.2",
-          "from": "strip-json-comments@1.0.x",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-        },
-        "underscore": {
-          "version": "1.6.0",
-          "from": "underscore@1.6.x",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
@@ -4229,11 +4074,6 @@
         }
       }
     },
-    "precommit-hook": {
-      "version": "1.0.7",
-      "from": "precommit-hook@1.0.7",
-      "resolved": "https://registry.npmjs.org/precommit-hook/-/precommit-hook-1.0.7.tgz"
-    },
     "q": {
       "version": "1.1.2",
       "from": "q@1.1.2",
@@ -4403,7 +4243,7 @@
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@2.0.4",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "grunt-template": "0.2.3",
     "grunt-todo": "0.4.0",
     "grunt-usemin": "3.0.0",
+    "husky": "0.6.2",
     "intern": "2.2.2",
     "jshint-stylish": "1.0.0",
-    "load-grunt-tasks": "3.1.0",
-    "precommit-hook": "1.0.7"
+    "load-grunt-tasks": "3.1.0"
   },
   "engines": {
     "node": ">=0.10.33"
@@ -65,9 +65,11 @@
   },
   "scripts": {
     "authors": "grunt contributors",
+    "clean": "rm -rf ./node_modules app/bower_components public && npm i --silent",
     "lint": "grunt lint",
     "outdated": "npm outdated --depth 0",
     "postinstall": "bower update --config.interactive=false -s",
+    "prepush": "npm run lint",
     "scss-lint": "scss-lint app/styles || true",
     "shrinkwrap": "npm shrinkwrap --dev && npm run validate-shrinkwrap",
     "start": "grunt serve",


### PR DESCRIPTION
Replacing **precommit-hook** module with [**husky**](https://www.npmjs.com/package/husky) so we can remove some sketchy automated JSHint logic included in **precommit-hook** and convert the hook from "pre-commit" to "pre-push". See https://github.com/mozilla/chronicle/issues/322 for some more context.

This doesn't address the core issue of #322 (_"git pre-commit linter should only run on files in the git index"_), but should give a slight performance bump (if you like to `git commit` a lot and `git push` a little).

### How do I even?

To install/test this, I recommend cleaning out any existing git hooks in your ./.git/hooks/ directory that may have been set up by **precommit-hook** _before_ running `npm install`. The **husky** npm install will recreate any hooks that it watches (notably "precommit", "prepush", and "postmerge").
