### PR TITLE
chore(deps): Update grunt-sass dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,13 +9,18 @@
       "dependencies": {
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "from": "cryptiles@2.x.x",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "hoek@2.x.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+        },
+        "wreck": {
+          "version": "5.2.0",
+          "from": "wreck@5.x.x",
+          "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz"
         }
       }
     },
@@ -26,7 +31,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "hoek@2.x.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -53,32 +58,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>=1.5.0",
+                  "from": "nomnom@>= 1.5.x",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@>=1.6.0 <1.7.0",
+                      "from": "underscore@~1.6.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@>=0.4.0 <0.5.0",
+                      "from": "chalk@~0.4.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@>=0.1.0 <0.2.0",
+                          "from": "has-color@~0.1.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@>=1.0.0 <1.1.0",
+                          "from": "ansi-styles@~1.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@>=0.1.0 <0.2.0",
+                          "from": "strip-ansi@~0.1.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -87,7 +92,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>=4.0.0",
+                  "from": "JSV@>= 4.0.x",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -111,12 +116,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -135,68 +140,68 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "bluebird": {
           "version": "2.8.2",
-          "from": "bluebird@>=2.8.2 <2.9.0",
+          "from": "bluebird@~2.8.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.8.2.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@>=0.5.2 <0.6.0",
+          "from": "forever-agent@~0.5.2",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "lodash": {
           "version": "3.2.0",
-          "from": "lodash@>=3.0.0 <4.0.0",
+          "from": "lodash@^3.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
         },
         "lodash-node": {
           "version": "2.4.1",
-          "from": "lodash-node@>=2.4.0 <2.5.0",
+          "from": "lodash-node@~2.4",
           "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
         }
       }
@@ -248,7 +253,7 @@
             },
             "debug": {
               "version": "2.1.1",
-              "from": "debug@>=2.0.0 <3.0.0",
+              "from": "debug@2",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
               "dependencies": {
                 "ms": {
@@ -265,7 +270,7 @@
             },
             "extend": {
               "version": "1.2.1",
-              "from": "extend@>=1.2.1 <1.3.0",
+              "from": "extend@~1.2.1",
               "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
             },
             "form-data": {
@@ -275,7 +280,7 @@
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "from": "combined-stream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -287,7 +292,7 @@
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "async@~0.9.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
@@ -299,7 +304,7 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -309,12 +314,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -342,22 +347,22 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@>=0.4.0 <0.5.0",
+      "from": "grunt@~0.4.2",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@>=0.1.22 <0.2.0",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "from": "coffee-script@~1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -367,37 +372,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "from": "eventemitter2@~0.4.13",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@~3.2.9",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -406,139 +411,139 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "graceful-fs@~1.2.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "from": "iconv-lite@~0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
+          "from": "minimatch@~0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.8 <2.3.0",
+          "from": "rimraf@~2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.8",
-          "from": "which@>=1.0.5 <1.1.0",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "from": "js-yaml@~2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "exit@~0.1.1",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "from": "grunt-legacy-util@~0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "from": "grunt-legacy-log@~0.1.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "from": "underscore.string@~2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -552,32 +557,32 @@
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.1.5",
-          "from": "autoprefixer-core@>=5.0.0 <6.0.0",
+          "from": "autoprefixer-core@^5.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.5.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.2.0",
-              "from": "browserslist@>=0.2.0 <0.3.0",
+              "from": "browserslist@~0.2.0",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
             },
             "num2fraction": {
               "version": "1.0.1",
-              "from": "num2fraction@>=1.0.1 <1.1.0",
+              "from": "num2fraction@~1.0.1",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000068",
-              "from": "caniuse-db@>=1.0.30000065 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000068.tgz"
+              "version": "1.0.30000072",
+              "from": "caniuse-db@^1.0.30000065",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000072.tgz"
             },
             "postcss": {
               "version": "4.0.4",
-              "from": "postcss@>=4.0.3 <4.1.0",
+              "from": "postcss@~4.0.3",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.4.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.2.0",
-                  "from": "source-map@>=0.2.0 <0.3.0",
+                  "from": "source-map@~0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -589,7 +594,7 @@
                 },
                 "js-base64": {
                   "version": "2.1.7",
-                  "from": "js-base64@>=2.1.7 <2.2.0",
+                  "from": "js-base64@~2.1.7",
                   "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz"
                 }
               }
@@ -598,51 +603,51 @@
         },
         "diff": {
           "version": "1.2.2",
-          "from": "diff@>=1.2.1 <1.3.0",
+          "from": "diff@~1.2.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.2.2.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.0 <0.6.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -656,7 +661,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.1 <2.3.0",
+          "from": "rimraf@~2.2.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
@@ -668,46 +673,46 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -721,42 +726,42 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jshint": {
           "version": "2.6.0",
-          "from": "jshint@>=2.6.0 <2.7.0",
+          "from": "jshint@~2.6.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
-              "from": "cli@>=0.6.0 <0.7.0",
+              "from": "cli@0.6.x",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "glob@~ 3.2.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "minimatch@0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -767,44 +772,44 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <1.2.0",
+              "from": "console-browserify@1.1.x",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "date-now@^0.1.4",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.0 <0.2.0",
+              "from": "exit@0.1.x",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "from": "htmlparser2@3.8.x",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "from": "domhandler@2.3",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "from": "domutils@1.5",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "from": "dom-serializer@0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
+                          "from": "entities@~1.1.1",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -813,17 +818,17 @@
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "readable-stream@1.1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -833,53 +838,53 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
+                  "from": "entities@1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <1.1.0",
+              "from": "minimatch@1.0.x",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
+              "from": "shelljs@0.3.x",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.0 <1.1.0",
+              "from": "strip-json-comments@1.0.x",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@>=1.6.0 <1.7.0",
+              "from": "underscore@1.6.x",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
@@ -893,49 +898,49 @@
       "dependencies": {
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@>=0.5.1 <0.6.0",
+          "from": "gaze@~0.5.1",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
+              "from": "globule@~0.1.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.1",
-                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "from": "lodash@~1.0.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
+                  "from": "glob@~3.1.21",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "from": "graceful-fs@~1.2.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "from": "inherits@1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "minimatch@~0.2.11",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -951,27 +956,27 @@
           "dependencies": {
             "qs": {
               "version": "0.5.6",
-              "from": "qs@>=0.5.2 <0.6.0",
+              "from": "qs@~0.5.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
-              "from": "faye-websocket@>=0.4.3 <0.5.0",
+              "from": "faye-websocket@~0.4.3",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
             "noptify": {
               "version": "0.0.3",
-              "from": "noptify@>=0.0.3 <0.1.0",
+              "from": "noptify@~0.0.3",
               "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
-                  "from": "nopt@>=2.0.0 <2.1.0",
+                  "from": "nopt@~2.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
@@ -980,19 +985,19 @@
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@>=0.7.0 <0.8.0",
+              "from": "debug@~0.7.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
@@ -1009,126 +1014,126 @@
           "dependencies": {
             "lodash.assign": {
               "version": "2.4.1",
-              "from": "lodash.assign@>=2.4.1 <2.5.0",
+              "from": "lodash.assign@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
               "dependencies": {
                 "lodash._basecreatecallback": {
                   "version": "2.4.1",
-                  "from": "lodash._basecreatecallback@>=2.4.1 <2.5.0",
+                  "from": "lodash._basecreatecallback@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
                   "dependencies": {
                     "lodash.bind": {
                       "version": "2.4.1",
-                      "from": "lodash.bind@>=2.4.1 <2.5.0",
+                      "from": "lodash.bind@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
                       "dependencies": {
                         "lodash._createwrapper": {
                           "version": "2.4.1",
-                          "from": "lodash._createwrapper@>=2.4.1 <2.5.0",
+                          "from": "lodash._createwrapper@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
                           "dependencies": {
                             "lodash._basebind": {
                               "version": "2.4.1",
-                              "from": "lodash._basebind@>=2.4.1 <2.5.0",
+                              "from": "lodash._basebind@~2.4.1",
                               "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
                               "dependencies": {
                                 "lodash._basecreate": {
                                   "version": "2.4.1",
-                                  "from": "lodash._basecreate@>=2.4.1 <2.5.0",
+                                  "from": "lodash._basecreate@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
                                   "dependencies": {
                                     "lodash._isnative": {
                                       "version": "2.4.1",
-                                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                      "from": "lodash._isnative@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                                     },
                                     "lodash.noop": {
                                       "version": "2.4.1",
-                                      "from": "lodash.noop@>=2.4.1 <2.5.0",
+                                      "from": "lodash.noop@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                                     }
                                   }
                                 },
                                 "lodash.isobject": {
                                   "version": "2.4.1",
-                                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                                  "from": "lodash.isobject@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                                 }
                               }
                             },
                             "lodash._basecreatewrapper": {
                               "version": "2.4.1",
-                              "from": "lodash._basecreatewrapper@>=2.4.1 <2.5.0",
+                              "from": "lodash._basecreatewrapper@~2.4.1",
                               "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
                               "dependencies": {
                                 "lodash._basecreate": {
                                   "version": "2.4.1",
-                                  "from": "lodash._basecreate@>=2.4.1 <2.5.0",
+                                  "from": "lodash._basecreate@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
                                   "dependencies": {
                                     "lodash._isnative": {
                                       "version": "2.4.1",
-                                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                      "from": "lodash._isnative@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                                     },
                                     "lodash.noop": {
                                       "version": "2.4.1",
-                                      "from": "lodash.noop@>=2.4.1 <2.5.0",
+                                      "from": "lodash.noop@~2.4.1",
                                       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                                     }
                                   }
                                 },
                                 "lodash.isobject": {
                                   "version": "2.4.1",
-                                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                                  "from": "lodash.isobject@~2.4.1",
                                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                                 }
                               }
                             },
                             "lodash.isfunction": {
                               "version": "2.4.1",
-                              "from": "lodash.isfunction@>=2.4.1 <2.5.0",
+                              "from": "lodash.isfunction@~2.4.1",
                               "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                             }
                           }
                         },
                         "lodash._slice": {
                           "version": "2.4.1",
-                          "from": "lodash._slice@>=2.4.1 <2.5.0",
+                          "from": "lodash._slice@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash.identity": {
                       "version": "2.4.1",
-                      "from": "lodash.identity@>=2.4.1 <2.5.0",
+                      "from": "lodash.identity@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
                     },
                     "lodash._setbinddata": {
                       "version": "2.4.1",
-                      "from": "lodash._setbinddata@>=2.4.1 <2.5.0",
+                      "from": "lodash._setbinddata@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
                       "dependencies": {
                         "lodash._isnative": {
                           "version": "2.4.1",
-                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                          "from": "lodash._isnative@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                         },
                         "lodash.noop": {
                           "version": "2.4.1",
-                          "from": "lodash.noop@>=2.4.1 <2.5.0",
+                          "from": "lodash.noop@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash.support": {
                       "version": "2.4.1",
-                      "from": "lodash.support@>=2.4.1 <2.5.0",
+                      "from": "lodash.support@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
                       "dependencies": {
                         "lodash._isnative": {
                           "version": "2.4.1",
-                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                          "from": "lodash._isnative@~2.4.1",
                           "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                         }
                       }
@@ -1137,56 +1142,56 @@
                 },
                 "lodash.keys": {
                   "version": "2.4.1",
-                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "from": "lodash.keys@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "from": "lodash._isnative@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
                     "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "from": "lodash.isobject@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                     },
                     "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "from": "lodash._shimkeys@~2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash._objecttypes": {
                   "version": "2.4.1",
-                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                  "from": "lodash._objecttypes@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                 }
               }
             },
             "event-stream": {
               "version": "3.1.7",
-              "from": "event-stream@>=3.1.0 <3.2.0",
+              "from": "event-stream@~3.1.0",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@>=2.3.1 <2.4.0",
+                  "from": "through@~2.3.1",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "duplexer@>=0.1.1 <0.2.0",
+                  "from": "duplexer@~0.1.1",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "from@>=0.0.0 <1.0.0",
+                  "from": "from@~0",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "map-stream@>=0.1.0 <0.2.0",
+                  "from": "map-stream@~0.1.0",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
@@ -1196,12 +1201,12 @@
                 },
                 "split": {
                   "version": "0.2.10",
-                  "from": "split@>=0.2.0 <0.3.0",
+                  "from": "split@0.2",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.4 <0.1.0",
+                  "from": "stream-combiner@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
@@ -1222,7 +1227,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.2.1",
-          "from": "lodash@>=2.2.1 <2.3.0",
+          "from": "lodash@~2.2.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
         }
       }
@@ -1239,27 +1244,27 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.11.3",
-          "from": "jscs@>=1.11.0 <1.12.0",
+          "from": "jscs@~1.11.0",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.11.3.tgz",
           "dependencies": {
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@>=0.3.1 <0.4.0",
+              "from": "cli-table@~0.3.1",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "colors@>=1.0.3 <1.1.0",
+              "from": "colors@~1.0.3",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "esprima": {
               "version": "1.2.4",
-              "from": "esprima@>=1.2.4 <1.3.0",
+              "from": "esprima@~1.2.4",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
             },
             "esprima-harmony-jscs": {
@@ -1269,44 +1274,44 @@
             },
             "estraverse": {
               "version": "1.9.1",
-              "from": "estraverse@>=1.9.1 <1.10.0",
+              "from": "estraverse@~1.9.1",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
+              "from": "exit@~0.1.2",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "4.3.5",
-              "from": "glob@>=4.3.5 <4.4.0",
+              "from": "glob@~4.3.5",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -1315,37 +1320,37 @@
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "lodash.assign@>=3.0.0 <3.1.0",
+              "from": "lodash.assign@~3.0.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.0.1",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "from": "lodash._baseassign@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.0.1.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.0",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "from": "lodash._basecopy@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
                     },
                     "lodash.keys": {
                       "version": "3.0.3",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "from": "lodash.keys@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.3.tgz",
                       "dependencies": {
                         "lodash.isarguments": {
                           "version": "3.0.0",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "from": "lodash.isarguments@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.0",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "from": "lodash.isarray@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
                         },
                         "lodash.isnative": {
                           "version": "3.0.0",
-                          "from": "lodash.isnative@>=3.0.0 <4.0.0",
+                          "from": "lodash.isnative@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
                         }
                       }
@@ -1354,17 +1359,17 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.0.0",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "from": "lodash._createassigner@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.0.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.0",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "from": "lodash._bindcallback@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.1",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "from": "lodash._isiterateecall@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.1.tgz"
                     }
                   }
@@ -1373,17 +1378,17 @@
             },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <2.1.0",
+              "from": "minimatch@~2.0.1",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -1397,39 +1402,39 @@
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@>=0.2.14 <0.3.0",
+              "from": "prompt@~0.2.14",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.3.0",
-                  "from": "pkginfo@>=0.0.0 <1.0.0",
+                  "from": "pkginfo@0.x.x",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "read": {
                   "version": "1.0.5",
-                  "from": "read@>=1.0.0 <1.1.0",
+                  "from": "read@1.0.x",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.4",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
+                      "from": "mute-stream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                     }
                   }
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "revalidator@>=0.1.0 <0.2.0",
+                  "from": "revalidator@0.1.x",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@>=0.2.0 <0.3.0",
+                  "from": "utile@0.2.x",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.9 <0.3.0",
+                      "from": "async@~0.2.9",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
@@ -1439,12 +1444,12 @@
                     },
                     "i": {
                       "version": "0.3.2",
-                      "from": "i@>=0.3.0 <0.4.0",
+                      "from": "i@0.3.x",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "mkdirp@>=0.0.0 <1.0.0",
+                      "from": "mkdirp@0.x.x",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
@@ -1456,49 +1461,49 @@
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "ncp@>=0.4.0 <0.5.0",
+                      "from": "ncp@0.4.x",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
+                      "from": "rimraf@2.x.x",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@>=0.8.0 <0.9.0",
+                  "from": "winston@0.8.x",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
+                      "from": "async@0.2.x",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "colors@>=0.6.0 <0.7.0",
+                      "from": "colors@0.6.x",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "cycle@>=1.0.0 <1.1.0",
+                      "from": "cycle@1.0.x",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "eyes@>=0.1.0 <0.2.0",
+                      "from": "eyes@0.1.x",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.1",
-                      "from": "isstream@>=0.1.0 <0.2.0",
+                      "from": "isstream@0.1.x",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "stack-trace@>=0.0.0 <0.1.0",
+                      "from": "stack-trace@0.0.x",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -1507,39 +1512,39 @@
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.2 <1.1.0",
+              "from": "strip-json-comments@~1.0.2",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "supports-color": {
               "version": "1.2.0",
-              "from": "supports-color@>=1.2.0 <1.3.0",
+              "from": "supports-color@~1.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@>=0.3.4 <0.4.0",
+              "from": "vow-fs@~0.3.4",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.2 <2.0.0",
+                  "from": "node-uuid@^1.4.2",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.1",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
+                  "from": "vow-queue@^0.4.1",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
                 }
               }
             },
             "xmlbuilder": {
               "version": "2.5.2",
-              "from": "xmlbuilder@>=2.5.0 <2.6.0",
+              "from": "xmlbuilder@~2.5.0",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.5.2.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.2.0",
-                  "from": "lodash@>=3.2.0 <3.3.0",
+                  "from": "lodash@~3.2.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                 }
               }
@@ -1548,12 +1553,12 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "vow": {
           "version": "0.4.8",
-          "from": "vow@>=0.4.1 <0.5.0",
+          "from": "vow@~0.4.1",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.8.tgz"
         }
       }
@@ -1570,32 +1575,32 @@
           "dependencies": {
             "nomnom": {
               "version": "1.8.1",
-              "from": "nomnom@>=1.5.0",
+              "from": "nomnom@>= 1.5.x",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "from": "underscore@~1.6.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "chalk@>=0.4.0 <0.5.0",
+                  "from": "chalk@~0.4.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "from": "has-color@>=0.1.0 <0.2.0",
+                      "from": "has-color@~0.1.0",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "ansi-styles@>=1.0.0 <1.1.0",
+                      "from": "ansi-styles@~1.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "strip-ansi@>=0.1.0 <0.2.0",
+                      "from": "strip-ansi@~0.1.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -1604,7 +1609,7 @@
             },
             "JSV": {
               "version": "4.0.2",
-              "from": "JSV@>=4.0.0",
+              "from": "JSV@>= 4.0.x",
               "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
             }
           }
@@ -1618,27 +1623,27 @@
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@>=0.2.3 <0.3.0",
+          "from": "cli-color@^0.2.3",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@>=0.9.2 <0.10.0",
+              "from": "es5-ext@~0.9.2",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@>=0.2.5 <0.3.0",
+              "from": "memoizee@~0.2.5",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@>=0.2.2 <0.3.0",
+                  "from": "event-emitter@~0.2.2",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@>=0.1.0 <0.2.0",
+                  "from": "next-tick@0.1.x",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -1647,22 +1652,22 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "colors@^0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "grunt": {
           "version": "0.4.5",
-          "from": "grunt@>=0.4.0 <0.5.0",
+          "from": "grunt@~0.4.2",
           "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.22",
-              "from": "async@>=0.1.22 <0.2.0",
+              "from": "async@~0.1.22",
               "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
             },
             "coffee-script": {
               "version": "1.3.3",
-              "from": "coffee-script@>=1.3.3 <1.4.0",
+              "from": "coffee-script@~1.3.3",
               "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
             },
             "dateformat": {
@@ -1672,37 +1677,37 @@
             },
             "eventemitter2": {
               "version": "0.4.14",
-              "from": "eventemitter2@>=0.4.13 <0.5.0",
+              "from": "eventemitter2@~0.4.13",
               "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
             },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@>=0.1.2 <0.2.0",
+              "from": "findup-sync@~0.1.2",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.9 <3.3.0",
+                  "from": "glob@~3.2.9",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "minimatch@0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -1711,139 +1716,139 @@
                 },
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "lodash@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.1.21",
-              "from": "glob@>=3.1.21 <3.2.0",
+              "from": "glob@~3.1.21",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                  "from": "graceful-fs@~1.2.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 },
                 "inherits": {
                   "version": "1.0.0",
-                  "from": "inherits@>=1.0.0 <2.0.0",
+                  "from": "inherits@1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 }
               }
             },
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@>=0.2.3 <0.3.0",
+              "from": "hooker@~0.2.3",
               "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@>=0.2.11 <0.3.0",
+              "from": "iconv-lite@~0.2.11",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.12 <0.3.0",
+              "from": "minimatch@~0.2.12",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@>=1.0.10 <1.1.0",
+              "from": "nopt@~1.0.10",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "abbrev@1",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.8 <2.3.0",
+              "from": "rimraf@~2.2.8",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "lodash": {
               "version": "0.9.2",
-              "from": "lodash@>=0.9.2 <0.10.0",
+              "from": "lodash@~0.9.2",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
             },
             "underscore.string": {
               "version": "2.2.1",
-              "from": "underscore.string@>=2.2.1 <2.3.0",
+              "from": "underscore.string@~2.2.1",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
             },
             "which": {
               "version": "1.0.8",
-              "from": "which@>=1.0.5 <1.1.0",
+              "from": "which@~1.0.5",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
             },
             "js-yaml": {
               "version": "2.0.5",
-              "from": "js-yaml@>=2.0.5 <2.1.0",
+              "from": "js-yaml@~2.0.5",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "0.1.16",
-                  "from": "argparse@>=0.1.11 <0.2.0",
+                  "from": "argparse@~ 0.1.11",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                   "dependencies": {
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@>=2.4.0 <2.5.0",
+                      "from": "underscore.string@~2.4.0",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@>=1.0.2 <1.1.0",
+                  "from": "esprima@~ 1.0.2",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.1 <0.2.0",
+              "from": "exit@~0.1.1",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "getobject": {
               "version": "0.1.0",
-              "from": "getobject@>=0.1.0 <0.2.0",
+              "from": "getobject@~0.1.0",
               "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
             },
             "grunt-legacy-util": {
               "version": "0.2.0",
-              "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+              "from": "grunt-legacy-util@~0.2.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
             },
             "grunt-legacy-log": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+              "from": "grunt-legacy-log@~0.1.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "lodash@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "from": "underscore.string@~2.3.3",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
@@ -1852,22 +1857,22 @@
         },
         "request": {
           "version": "2.53.0",
-          "from": "request@>=2.53.0 <3.0.0",
+          "from": "request@^2.34.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "bl@~0.9.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "readable-stream@~1.0.26",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -1877,12 +1882,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1891,56 +1896,56 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
+              "from": "caseless@~0.9.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "forever-agent@~0.5.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
+              "from": "form-data@~0.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "async@~0.9.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "json-stringify-safe@~5.0.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.1 <2.1.0",
+              "from": "mime-types@~2.0.1",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
+                  "from": "mime-db@~1.7.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "node-uuid@~1.4.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "qs": {
               "version": "2.3.3",
-              "from": "qs@>=2.3.1 <2.4.0",
+              "from": "qs@~2.3.1",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@~0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
@@ -1957,12 +1962,12 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "http-signature@~0.10.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -1979,44 +1984,44 @@
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "from": "oauth-sign@~0.6.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
+              "from": "hawk@~2.3.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.11.0",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "hoek@2.x.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "cryptiles@2.x.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "aws-sign2@~0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "stringstream@~0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "from": "combined-stream@~0.0.5",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -2028,14 +2033,14 @@
             },
             "isstream": {
               "version": "0.1.1",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "isstream@~0.1.1",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -2047,42 +2052,42 @@
       "dependencies": {
         "requirejs": {
           "version": "2.1.16",
-          "from": "requirejs@>=2.1.0 <2.2.0",
+          "from": "requirejs@2.1.x",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz"
         },
         "cheerio": {
           "version": "0.13.1",
-          "from": "cheerio@>=0.13.0 <0.14.0",
+          "from": "cheerio@0.13.x",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.4.0",
-              "from": "htmlparser2@>=3.4.0 <3.5.0",
+              "from": "htmlparser2@~3.4.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "domhandler@>=2.2.0 <2.3.0",
+                  "from": "domhandler@2.2",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.3.0",
-                  "from": "domutils@>=1.3.0 <1.4.0",
+                  "from": "domutils@1.3",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "domelementtype@1",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "readable-stream@1.1",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -2092,12 +2097,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -2106,32 +2111,32 @@
             },
             "underscore": {
               "version": "1.5.2",
-              "from": "underscore@>=1.5.0 <1.6.0",
+              "from": "underscore@~1.5",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@>=0.0.0 <1.0.0",
+              "from": "entities@0.x",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "from": "CSSselect@~0.4.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "from": "CSSwhat@0.4",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "from": "domutils@1.4",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "from": "domelementtype@1",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
@@ -2142,29 +2147,29 @@
         },
         "almond": {
           "version": "0.2.9",
-          "from": "almond@>=0.2.0 <0.3.0",
+          "from": "almond@0.2.x",
           "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
         },
         "gzip-js": {
           "version": "0.3.2",
-          "from": "gzip-js@>=0.3.0 <0.4.0",
+          "from": "gzip-js@0.3.x",
           "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "dependencies": {
             "crc32": {
               "version": "0.2.2",
-              "from": "crc32@>=0.2.2",
+              "from": "crc32@>= 0.2.2",
               "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
             },
             "deflate-js": {
               "version": "0.2.3",
-              "from": "deflate-js@>=0.2.2",
+              "from": "deflate-js@>= 0.2.2",
               "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
             }
           }
         },
         "q": {
           "version": "0.8.12",
-          "from": "q@>=0.8.0 <0.9.0",
+          "from": "q@0.8.x",
           "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
         }
       }
@@ -2181,129 +2186,129 @@
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
+          "from": "each-async@^1.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
+              "from": "onetime@^1.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.0",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "from": "set-immediate-shim@^1.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
             }
           }
         },
         "node-sass": {
           "version": "2.0.1",
-          "from": "node-sass@>=2.0.1 <3.0.0",
+          "from": "node-sass@^2.0.1",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
+              "from": "chalk@^0.5.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "ansi-styles@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "has-ansi@^0.1.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "strip-ansi@^0.3.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "supports-color@^0.2.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "cross-spawn": {
               "version": "0.2.6",
-              "from": "cross-spawn@>=0.2.6 <0.3.0",
+              "from": "cross-spawn@^0.2.6",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.5.0 <3.0.0",
+                  "from": "lru-cache@^2.5.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "gaze@>=0.5.1 <0.6.0",
+              "from": "gaze@^0.5.1",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "globule@>=0.1.0 <0.2.0",
+                  "from": "globule@~0.1.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.1",
-                      "from": "lodash@>=1.0.1 <1.1.0",
+                      "from": "lodash@~1.0.1",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "glob@>=3.1.21 <3.2.0",
+                      "from": "glob@~3.1.21",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "graceful-fs@>=1.2.0 <1.3.0",
+                          "from": "graceful-fs@~1.2.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.0",
-                          "from": "inherits@>=1.0.0 <2.0.0",
+                          "from": "inherits@1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "from": "minimatch@~0.2.11",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -2314,44 +2319,44 @@
             },
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "get-stdin@^4.0.1",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.0.0",
-              "from": "meow@>=3.0.0 <4.0.0",
+              "from": "meow@^3.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.0.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "camelcase-keys@^1.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.0.2",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "camelcase@^1.0.1",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.0",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "map-obj@^1.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "indent-string@^1.1.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.2",
-                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "from": "repeating@^1.1.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.0",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "is-finite@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                         }
                       }
@@ -2360,14 +2365,14 @@
                 },
                 "minimist": {
                   "version": "1.1.0",
-                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "from": "minimist@^1.1.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "mkdirp@^0.5.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
@@ -2379,7 +2384,7 @@
             },
             "mocha": {
               "version": "2.1.0",
-              "from": "mocha@>=2.1.0 <3.0.0",
+              "from": "mocha@^2.1.0",
               "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
               "dependencies": {
                 "commander": {
@@ -2416,29 +2421,29 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "from": "minimatch@~0.2.11",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "from": "graceful-fs@~2.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -2469,63 +2474,63 @@
             },
             "nan": {
               "version": "1.6.2",
-              "from": "nan@>=1.6.2 <2.0.0",
+              "from": "nan@^1.6.2",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
             },
             "npmconf": {
               "version": "2.1.1",
-              "from": "npmconf@>=2.1.1 <3.0.0",
+              "from": "npmconf@^2.1.1",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.8",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "from": "config-chain@~1.1.8",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.3",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "from": "proto-list@~1.2.1",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@~2.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.3",
-                  "from": "ini@>=1.2.0 <2.0.0",
+                  "from": "ini@^1.2.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                 },
                 "nopt": {
                   "version": "3.0.1",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "nopt@~3.0.1",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@~1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.0",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "osenv@^0.1.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
                 },
                 "uid-number": {
@@ -2542,22 +2547,22 @@
             },
             "request": {
               "version": "2.53.0",
-              "from": "request@>=2.53.0 <3.0.0",
+              "from": "request@^2.53.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "readable-stream@~1.0.26",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -2567,12 +2572,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -2581,56 +2586,56 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "from": "caseless@~0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "forever-agent@~0.5.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "form-data@~0.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "async@~0.9.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.9",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "from": "mime-types@~2.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "mime-db@>=1.7.0 <1.8.0",
+                      "from": "mime-db@~1.7.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
+                  "from": "qs@~2.3.1",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
@@ -2647,12 +2652,12 @@
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "http-signature@~0.10.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "assert-plus@^0.1.5",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -2669,44 +2674,44 @@
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "from": "oauth-sign@~0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "from": "hawk@~2.3.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.11.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "combined-stream@~0.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -2718,51 +2723,51 @@
                 },
                 "isstream": {
                   "version": "0.1.1",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "isstream@~0.1.1",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
                 }
               }
             },
             "sass-graph": {
               "version": "1.0.3",
-              "from": "sass-graph@>=1.0.3 <2.0.0",
+              "from": "sass-graph@^1.0.3",
               "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.4 <5.0.0",
+                  "from": "glob@^4.3.4",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.1",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "minimatch@^2.0.1",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "brace-expansion@^1.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "from": "balanced-match@^0.2.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                             },
                             "concat-map": {
@@ -2776,12 +2781,12 @@
                     },
                     "once": {
                       "version": "1.3.1",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -2790,26 +2795,26 @@
                 },
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@>=2.4.1 <3.0.0",
+                  "from": "lodash@^2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.0",
-              "from": "semver@>=4.2.2 <5.0.0",
+              "from": "semver@^4.2.2",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
+              "from": "shelljs@^0.3.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "object-assign@^2.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         }
       }
@@ -2826,53 +2831,53 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.0 <0.6.0",
+          "from": "chalk@~0.5",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "text-table@~0.2",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -2884,53 +2889,53 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@>=2.1.0 <2.2.0",
+          "from": "debug@~2.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
@@ -2942,7 +2947,7 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
@@ -3004,7 +3009,7 @@
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2.5.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             }
           }
@@ -3133,7 +3138,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "hoek@2.x.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -3150,49 +3155,49 @@
           "dependencies": {
             "esprima": {
               "version": "1.2.4",
-              "from": "esprima@>=1.2.0 <1.3.0",
+              "from": "esprima@1.2.x",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
             },
             "escodegen": {
               "version": "1.3.3",
-              "from": "escodegen@>=1.3.0 <1.4.0",
+              "from": "escodegen@1.3.x",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.0.0",
-                  "from": "esutils@>=1.0.0 <1.1.0",
+                  "from": "esutils@~1.0.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                 },
                 "estraverse": {
                   "version": "1.5.1",
-                  "from": "estraverse@>=1.5.0 <1.6.0",
+                  "from": "estraverse@~1.5.0",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                 },
                 "esprima": {
                   "version": "1.1.1",
-                  "from": "esprima@>=1.1.1 <1.2.0",
+                  "from": "esprima@~1.1.1",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                 }
               }
             },
             "handlebars": {
               "version": "1.3.0",
-              "from": "handlebars@>=1.3.0 <1.4.0",
+              "from": "handlebars@1.3.x",
               "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@>=0.3.0 <0.4.0",
+                  "from": "optimist@~0.3",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "from": "uglify-js@~2.3",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
+                      "from": "async@~0.2.6",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     }
                   }
@@ -3201,7 +3206,7 @@
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "mkdirp@0.5.x",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
@@ -3213,54 +3218,54 @@
             },
             "nopt": {
               "version": "3.0.1",
-              "from": "nopt@>=3.0.0 <4.0.0",
+              "from": "nopt@3.x",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
             },
             "fileset": {
               "version": "0.1.5",
-              "from": "fileset@>=0.1.0 <0.2.0",
+              "from": "fileset@0.1.x",
               "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.4.0",
-                  "from": "minimatch@>=0.0.0 <1.0.0",
+                  "from": "minimatch@0.x",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.0.0 <4.0.0",
+                  "from": "glob@3.x",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "minimatch@0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -3271,49 +3276,49 @@
             },
             "which": {
               "version": "1.0.8",
-              "from": "which@>=1.0.0 <1.1.0",
+              "from": "which@1.0.x",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "async@0.9.x",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <1.1.0",
+              "from": "abbrev@1.0.x",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             },
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.0 <0.1.0",
+              "from": "wordwrap@0.0.x",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "resolve@>=0.7.0 <0.8.0",
+              "from": "resolve@0.7.x",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "js-yaml": {
               "version": "3.2.6",
-              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "from": "js-yaml@3.x",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.6.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "0.1.16",
-                  "from": "argparse@>=0.1.11 <0.2.0",
+                  "from": "argparse@~ 0.1.11",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                   "dependencies": {
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@>=2.4.0 <2.5.0",
+                      "from": "underscore.string@~2.4.0",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@>=1.0.2 <1.1.0",
+                  "from": "esprima@~ 1.0.2",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
@@ -3390,27 +3395,27 @@
               "dependencies": {
                 "adm-zip": {
                   "version": "0.4.7",
-                  "from": "adm-zip@>=0.4.3 <0.5.0",
+                  "from": "adm-zip@^0.4.3",
                   "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
                 },
                 "extname": {
                   "version": "0.1.5",
-                  "from": "extname@>=0.1.1 <0.2.0",
+                  "from": "extname@^0.1.1",
                   "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.5.tgz",
                   "dependencies": {
                     "ext-list": {
                       "version": "0.2.0",
-                      "from": "ext-list@>=0.2.0 <0.3.0",
+                      "from": "ext-list@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
                       "dependencies": {
                         "got": {
                           "version": "0.2.0",
-                          "from": "got@>=0.2.0 <0.3.0",
+                          "from": "got@^0.2.0",
                           "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
                           "dependencies": {
                             "object-assign": {
                               "version": "0.3.1",
-                              "from": "object-assign@>=0.3.0 <0.4.0",
+                              "from": "object-assign@^0.3.0",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
                             }
                           }
@@ -3419,70 +3424,70 @@
                     },
                     "underscore.string": {
                       "version": "2.3.3",
-                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "from": "underscore.string@~2.3.3",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                     }
                   }
                 },
                 "get-stdin": {
                   "version": "0.1.0",
-                  "from": "get-stdin@>=0.1.0 <0.2.0",
+                  "from": "get-stdin@^0.1.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
                 },
                 "map-key": {
                   "version": "0.1.5",
-                  "from": "map-key@>=0.1.1 <0.2.0",
+                  "from": "map-key@^0.1.1",
                   "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.5.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "2.4.1",
-                      "from": "lodash@>=2.4.1 <3.0.0",
+                      "from": "lodash@^2.4.1",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                     },
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@>=2.3.3 <3.0.0",
+                      "from": "underscore.string@^2.3.3",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "from": "mkdirp@^0.3.5",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "nopt": {
                   "version": "2.2.1",
-                  "from": "nopt@>=2.2.0 <3.0.0",
+                  "from": "nopt@^2.2.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@>=2.2.2 <3.0.0",
+                  "from": "rimraf@^2.2.2",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.4 <0.0.5",
+                  "from": "stream-combiner@^0.0.4",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "dependencies": {
                     "duplexer": {
                       "version": "0.1.1",
-                      "from": "duplexer@>=0.1.1 <0.2.0",
+                      "from": "duplexer@~0.1.1",
                       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                     }
                   }
                 },
                 "tar": {
                   "version": "0.1.20",
-                  "from": "tar@>=0.1.18 <0.2.0",
+                  "from": "tar@^0.1.18",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
                   "dependencies": {
                     "block-stream": {
@@ -3492,17 +3497,17 @@
                     },
                     "fstream": {
                       "version": "0.1.31",
-                      "from": "fstream@>=0.1.28 <0.2.0",
+                      "from": "fstream@~0.1.28",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "3.0.5",
-                          "from": "graceful-fs@>=3.0.2 <3.1.0",
+                          "from": "graceful-fs@~3.0.2",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                         },
                         "mkdirp": {
                           "version": "0.5.0",
-                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "from": "mkdirp@0.5",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
@@ -3516,19 +3521,19 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "tempfile": {
                   "version": "0.1.3",
-                  "from": "tempfile@>=0.1.2 <0.2.0",
+                  "from": "tempfile@^0.1.2",
                   "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
                   "dependencies": {
                     "uuid": {
                       "version": "1.4.2",
-                      "from": "uuid@>=1.4.0 <1.5.0",
+                      "from": "uuid@~1.4.0",
                       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
                     }
                   }
@@ -3556,59 +3561,59 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
+          "from": "hoek@^2.2.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@>=1.0.0 <2.0.0",
+          "from": "topo@1.x.x",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "isemail@>=1.0.0 <2.0.0",
+          "from": "isemail@1.x.x",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
           "version": "2.9.0",
-          "from": "moment@>=2.0.0 <3.0.0",
+          "from": "moment@2.x.x",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
         }
       }
     },
     "jshint": {
       "version": "2.6.0",
-      "from": "jshint@*",
+      "from": "jshint@",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.5",
-          "from": "cli@>=0.6.0 <0.7.0",
+          "from": "cli@0.6.x",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "glob@~ 3.2.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3619,44 +3624,44 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "from": "console-browserify@1.1.x",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "date-now@^0.1.4",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.0 <0.2.0",
+          "from": "exit@0.1.x",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@>=3.8.0 <3.9.0",
+          "from": "htmlparser2@3.8.x",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@>=2.3.0 <2.4.0",
+              "from": "domhandler@2.3",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@>=1.5.0 <1.6.0",
+              "from": "domutils@1.5",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "from": "dom-serializer@0",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@>=1.1.1 <1.2.0",
+                      "from": "entities@~1.1.1",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -3665,17 +3670,17 @@
             },
             "domelementtype": {
               "version": "1.1.3",
-              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "from": "domelementtype@1",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "from": "readable-stream@1.1",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -3685,53 +3690,53 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@>=1.0.0 <1.1.0",
+              "from": "entities@1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@>=1.0.0 <1.1.0",
+          "from": "minimatch@1.0.x",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "shelljs@>=0.3.0 <0.4.0",
+          "from": "shelljs@0.3.x",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@>=1.0.0 <1.1.0",
+          "from": "strip-json-comments@1.0.x",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
+          "from": "underscore@1.6.x",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
@@ -3743,68 +3748,68 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.1",
-          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "from": "log-symbols@^1.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
         },
         "string-length": {
           "version": "1.0.0",
-          "from": "string-length@>=1.0.0 <2.0.0",
+          "from": "string-length@^1.0.0",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.0 <3.0.0",
+              "from": "strip-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.0",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "ansi-regex@^1.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
                 }
               }
@@ -3813,7 +3818,7 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -3825,44 +3830,44 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.2.1",
-          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "from": "findup-sync@^0.2.1",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
           "dependencies": {
             "glob": {
               "version": "4.3.5",
-              "from": "glob@>=4.3.0 <4.4.0",
+              "from": "glob@~4.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.1",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "minimatch@^2.0.1",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -3876,12 +3881,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3892,39 +3897,39 @@
         },
         "multimatch": {
           "version": "2.0.0",
-          "from": "multimatch@>=2.0.0 <3.0.0",
+          "from": "multimatch@^2.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "array-differ@>=1.0.0 <2.0.0",
+              "from": "array-differ@^1.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
+              "from": "array-union@^1.0.1",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "from": "array-uniq@^1.0.1",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "minimatch@^2.0.1",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -3947,85 +3952,85 @@
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@>=1.0.0 <2.0.0",
+          "from": "intel@^1.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
+              "from": "chalk@~0.5.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "ansi-styles@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "has-ansi@^0.1.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "strip-ansi@^0.3.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "supports-color@^0.2.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@>=0.4.2 <0.5.0",
+              "from": "dbug@~0.4.2",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.9 <0.1.0",
+              "from": "stack-trace@~0.0.9",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "strftime@>=0.8.2 <0.9.0",
+              "from": "strftime@~0.8.2",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@>=0.2.0 <0.3.0",
+              "from": "symbol@~0.2.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@>=0.1.0 <0.2.0",
+              "from": "utcstring@~0.1.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@>=1.2.0 <2.0.0",
+          "from": "merge@^1.2.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
@@ -4037,7 +4042,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "async@~0.9.x",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         }
       }
@@ -4049,73 +4054,73 @@
       "dependencies": {
         "buildmail": {
           "version": "1.2.0",
-          "from": "buildmail@>=1.2.0 <2.0.0",
+          "from": "buildmail@^1.2.0",
           "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-1.2.0.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "addressparser@>=0.3.1 <0.4.0",
+              "from": "addressparser@^0.3.1",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
-              "from": "libbase64@>=0.1.0 <0.2.0",
+              "from": "libbase64@^0.1.0",
               "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
             },
             "libqp": {
               "version": "0.1.1",
-              "from": "libqp@>=0.1.1 <0.2.0",
+              "from": "libqp@^0.1.1",
               "resolved": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz"
             }
           }
         },
         "hyperquest": {
           "version": "0.3.0",
-          "from": "hyperquest@>=0.3.0 <0.4.0",
+          "from": "hyperquest@^0.3.0",
           "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-0.3.0.tgz",
           "dependencies": {
             "through": {
               "version": "2.2.7",
-              "from": "through@>=2.2.0 <2.3.0",
+              "from": "through@~2.2.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
             },
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@>=0.1.0 <0.2.0",
+              "from": "duplexer@~0.1.0",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             }
           }
         },
         "libmime": {
           "version": "0.1.7",
-          "from": "libmime@>=0.1.5 <0.2.0",
+          "from": "libmime@^0.1.5",
           "resolved": "https://registry.npmjs.org/libmime/-/libmime-0.1.7.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.7",
-              "from": "iconv-lite@>=0.4.4 <0.5.0",
+              "from": "iconv-lite@^0.4.4",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
-              "from": "libbase64@>=0.1.0 <0.2.0",
+              "from": "libbase64@^0.1.0",
               "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
             },
             "libqp": {
               "version": "0.1.1",
-              "from": "libqp@>=0.1.1 <0.2.0",
+              "from": "libqp@^0.1.1",
               "resolved": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz"
             }
           }
         },
         "nodemailer-direct-transport": {
           "version": "1.0.0",
-          "from": "nodemailer-direct-transport@>=1.0.0 <2.0.0",
+          "from": "nodemailer-direct-transport@^1.0.0",
           "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.0.tgz",
           "dependencies": {
             "smtp-connection": {
               "version": "0.1.7",
-              "from": "smtp-connection@>=0.1.5 <0.2.0",
+              "from": "smtp-connection@^0.1.5",
               "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-0.1.7.tgz"
             }
           }
@@ -4129,12 +4134,12 @@
       "dependencies": {
         "nodemailer-wellknown": {
           "version": "0.1.5",
-          "from": "nodemailer-wellknown@>=0.1.1 <0.2.0",
+          "from": "nodemailer-wellknown@^0.1.1",
           "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.5.tgz"
         },
         "smtp-connection": {
           "version": "1.1.0",
-          "from": "smtp-connection@>=1.0.0 <2.0.0",
+          "from": "smtp-connection@^1.0.0",
           "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz"
         }
       }
@@ -4176,12 +4181,12 @@
           "dependencies": {
             "split": {
               "version": "0.3.3",
-              "from": "split@>=0.3.0 <0.4.0",
+              "from": "split@~0.3",
               "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@>=2.0.0 <3.0.0",
+                  "from": "through@2",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
@@ -4190,7 +4195,7 @@
         },
         "semver": {
           "version": "4.3.0",
-          "from": "semver@>=4.1.0 <5.0.0",
+          "from": "semver@^4.1.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
         }
       }
@@ -4202,24 +4207,24 @@
       "dependencies": {
         "xtend": {
           "version": "2.1.2",
-          "from": "xtend@>=2.1.1 <2.2.0",
+          "from": "xtend@~2.1.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "dependencies": {
             "object-keys": {
               "version": "0.4.0",
-              "from": "object-keys@>=0.4.0 <0.5.0",
+              "from": "object-keys@~0.4.0",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "argh": {
           "version": "0.1.3",
-          "from": "argh@>=0.1.1 <0.2.0",
+          "from": "argh@~0.1.1",
           "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.3.tgz"
         }
       }
@@ -4256,22 +4261,22 @@
       "dependencies": {
         "request": {
           "version": "2.53.0",
-          "from": "request@>=2.53.0 <3.0.0",
+          "from": "request@^2.34.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "bl@~0.9.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "readable-stream@~1.0.26",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -4281,12 +4286,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4295,56 +4300,56 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
+              "from": "caseless@~0.9.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "forever-agent@~0.5.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
+              "from": "form-data@~0.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "async@~0.9.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "json-stringify-safe@~5.0.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@>=2.0.1 <2.1.0",
+              "from": "mime-types@~2.0.1",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@>=1.7.0 <1.8.0",
+                  "from": "mime-db@~1.7.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "node-uuid@~1.4.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "qs": {
               "version": "2.3.3",
-              "from": "qs@>=2.3.1 <2.4.0",
+              "from": "qs@~2.3.1",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@~0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
@@ -4361,12 +4366,12 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "http-signature@~0.10.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -4383,44 +4388,44 @@
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "from": "oauth-sign@~0.6.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
+              "from": "hawk@~2.3.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.11.0",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "hoek@2.x.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "cryptiles@2.x.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "aws-sign2@~0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "stringstream@~0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "from": "combined-stream@~0.0.5",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -4432,7 +4437,7 @@
             },
             "isstream": {
               "version": "0.1.1",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "isstream@~0.1.1",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             }
           }
@@ -4443,18 +4448,6 @@
       "version": "2.0.1",
       "from": "uuid@2.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-    },
-    "wreck": {
-      "version": "5.2.0",
-      "from": "wreck@5.2.0",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz",
-      "dependencies": {
-        "hoek": {
-          "version": "2.11.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
-        }
-      }
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,12 +9,12 @@
       "dependencies": {
         "cryptiles": {
           "version": "2.0.4",
-          "from": "cryptiles@2.x.x",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -26,7 +26,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -53,32 +53,32 @@
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -87,7 +87,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -111,12 +111,12 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -135,68 +135,68 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "bluebird": {
           "version": "2.8.2",
-          "from": "bluebird@~2.8.2",
+          "from": "bluebird@>=2.8.2 <2.9.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.8.2.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.2",
+          "from": "forever-agent@>=0.5.2 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "lodash": {
           "version": "3.2.0",
-          "from": "lodash@^3.0.0",
+          "from": "lodash@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
         },
         "lodash-node": {
           "version": "2.4.1",
-          "from": "lodash-node@~2.4",
+          "from": "lodash-node@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
         }
       }
@@ -248,7 +248,7 @@
             },
             "debug": {
               "version": "2.1.1",
-              "from": "debug@2",
+              "from": "debug@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
               "dependencies": {
                 "ms": {
@@ -265,7 +265,7 @@
             },
             "extend": {
               "version": "1.2.1",
-              "from": "extend@~1.2.1",
+              "from": "extend@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
             },
             "form-data": {
@@ -275,7 +275,7 @@
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.4",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -287,7 +287,7 @@
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@~0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
@@ -299,7 +299,7 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -309,12 +309,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -342,22 +342,22 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@^0.4.4",
+      "from": "grunt@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -367,37 +367,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -406,139 +406,139 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.8",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -552,32 +552,32 @@
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.1.5",
-          "from": "autoprefixer-core@^5.0.0",
+          "from": "autoprefixer-core@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.5.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.2.0",
-              "from": "browserslist@~0.2.0",
+              "from": "browserslist@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
             },
             "num2fraction": {
               "version": "1.0.1",
-              "from": "num2fraction@~1.0.1",
+              "from": "num2fraction@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000067",
-              "from": "caniuse-db@^1.0.30000065",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000067.tgz"
+              "version": "1.0.30000068",
+              "from": "caniuse-db@>=1.0.30000065 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000068.tgz"
             },
             "postcss": {
-              "version": "4.0.3",
-              "from": "postcss@~4.0.3",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.3.tgz",
+              "version": "4.0.4",
+              "from": "postcss@>=4.0.3 <4.1.0",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.4.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.2.0",
-                  "from": "source-map@~0.2.0",
+                  "from": "source-map@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -589,7 +589,7 @@
                 },
                 "js-base64": {
                   "version": "2.1.7",
-                  "from": "js-base64@~2.1.7",
+                  "from": "js-base64@>=2.1.7 <2.2.0",
                   "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.7.tgz"
                 }
               }
@@ -598,51 +598,51 @@
         },
         "diff": {
           "version": "1.2.2",
-          "from": "diff@~1.2.1",
+          "from": "diff@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.2.2.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -656,7 +656,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.1",
+          "from": "rimraf@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
@@ -668,46 +668,46 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -721,42 +721,42 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jshint": {
           "version": "2.6.0",
-          "from": "jshint@~2.6.0",
+          "from": "jshint@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
-              "from": "cli@0.6.x",
+              "from": "cli@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@~ 3.2.1",
+                  "from": "glob@>=3.2.1 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@0.3",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -767,44 +767,44 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@1.1.x",
+              "from": "console-browserify@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@^0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@0.1.x",
+              "from": "exit@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "htmlparser2@3.8.x",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "domhandler@2.3",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@1.5",
+                  "from": "domutils@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@~1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -813,17 +813,17 @@
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "domelementtype@1",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -833,53 +833,53 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@1.0",
+                  "from": "entities@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@1.0.x",
+              "from": "minimatch@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@0.3.x",
+              "from": "shelljs@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@1.0.x",
+              "from": "strip-json-comments@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@1.6.x",
+              "from": "underscore@>=1.6.0 <1.7.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
@@ -893,49 +893,49 @@
       "dependencies": {
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@~0.5.1",
+          "from": "gaze@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@~0.1.0",
+              "from": "globule@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.1",
-                  "from": "lodash@~1.0.1",
+                  "from": "lodash@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@~3.1.21",
+                  "from": "glob@>=3.1.21 <3.2.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@~1.2.0",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "inherits@1",
+                      "from": "inherits@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -951,27 +951,27 @@
           "dependencies": {
             "qs": {
               "version": "0.5.6",
-              "from": "qs@~0.5.2",
+              "from": "qs@>=0.5.2 <0.6.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
-              "from": "faye-websocket@~0.4.3",
+              "from": "faye-websocket@>=0.4.3 <0.5.0",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
             "noptify": {
               "version": "0.0.3",
-              "from": "noptify@~0.0.3",
+              "from": "noptify@>=0.0.3 <0.1.0",
               "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
-                  "from": "nopt@~2.0.0",
+                  "from": "nopt@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
@@ -980,19 +980,19 @@
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@~0.7.0",
+              "from": "debug@>=0.7.0 <0.8.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
@@ -1009,126 +1009,126 @@
           "dependencies": {
             "lodash.assign": {
               "version": "2.4.1",
-              "from": "lodash.assign@~2.4.1",
+              "from": "lodash.assign@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
               "dependencies": {
                 "lodash._basecreatecallback": {
                   "version": "2.4.1",
-                  "from": "lodash._basecreatecallback@~2.4.1",
+                  "from": "lodash._basecreatecallback@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
                   "dependencies": {
                     "lodash.bind": {
                       "version": "2.4.1",
-                      "from": "lodash.bind@~2.4.1",
+                      "from": "lodash.bind@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
                       "dependencies": {
                         "lodash._createwrapper": {
                           "version": "2.4.1",
-                          "from": "lodash._createwrapper@~2.4.1",
+                          "from": "lodash._createwrapper@>=2.4.1 <2.5.0",
                           "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
                           "dependencies": {
                             "lodash._basebind": {
                               "version": "2.4.1",
-                              "from": "lodash._basebind@~2.4.1",
+                              "from": "lodash._basebind@>=2.4.1 <2.5.0",
                               "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
                               "dependencies": {
                                 "lodash._basecreate": {
                                   "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
+                                  "from": "lodash._basecreate@>=2.4.1 <2.5.0",
                                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
                                   "dependencies": {
                                     "lodash._isnative": {
                                       "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
+                                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
                                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                                     },
                                     "lodash.noop": {
                                       "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
+                                      "from": "lodash.noop@>=2.4.1 <2.5.0",
                                       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                                     }
                                   }
                                 },
                                 "lodash.isobject": {
                                   "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
+                                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
                                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                                 }
                               }
                             },
                             "lodash._basecreatewrapper": {
                               "version": "2.4.1",
-                              "from": "lodash._basecreatewrapper@~2.4.1",
+                              "from": "lodash._basecreatewrapper@>=2.4.1 <2.5.0",
                               "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
                               "dependencies": {
                                 "lodash._basecreate": {
                                   "version": "2.4.1",
-                                  "from": "lodash._basecreate@~2.4.1",
+                                  "from": "lodash._basecreate@>=2.4.1 <2.5.0",
                                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
                                   "dependencies": {
                                     "lodash._isnative": {
                                       "version": "2.4.1",
-                                      "from": "lodash._isnative@~2.4.1",
+                                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
                                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                                     },
                                     "lodash.noop": {
                                       "version": "2.4.1",
-                                      "from": "lodash.noop@~2.4.1",
+                                      "from": "lodash.noop@>=2.4.1 <2.5.0",
                                       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                                     }
                                   }
                                 },
                                 "lodash.isobject": {
                                   "version": "2.4.1",
-                                  "from": "lodash.isobject@~2.4.1",
+                                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
                                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                                 }
                               }
                             },
                             "lodash.isfunction": {
                               "version": "2.4.1",
-                              "from": "lodash.isfunction@~2.4.1",
+                              "from": "lodash.isfunction@>=2.4.1 <2.5.0",
                               "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                             }
                           }
                         },
                         "lodash._slice": {
                           "version": "2.4.1",
-                          "from": "lodash._slice@~2.4.1",
+                          "from": "lodash._slice@>=2.4.1 <2.5.0",
                           "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash.identity": {
                       "version": "2.4.1",
-                      "from": "lodash.identity@~2.4.1",
+                      "from": "lodash.identity@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
                     },
                     "lodash._setbinddata": {
                       "version": "2.4.1",
-                      "from": "lodash._setbinddata@~2.4.1",
+                      "from": "lodash._setbinddata@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
                       "dependencies": {
                         "lodash._isnative": {
                           "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
+                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
                           "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                         },
                         "lodash.noop": {
                           "version": "2.4.1",
-                          "from": "lodash.noop@~2.4.1",
+                          "from": "lodash.noop@>=2.4.1 <2.5.0",
                           "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash.support": {
                       "version": "2.4.1",
-                      "from": "lodash.support@~2.4.1",
+                      "from": "lodash.support@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
                       "dependencies": {
                         "lodash._isnative": {
                           "version": "2.4.1",
-                          "from": "lodash._isnative@~2.4.1",
+                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
                           "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                         }
                       }
@@ -1137,56 +1137,56 @@
                 },
                 "lodash.keys": {
                   "version": "2.4.1",
-                  "from": "lodash.keys@~2.4.1",
+                  "from": "lodash.keys@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@~2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
                     "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "lodash.isobject@~2.4.1",
+                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
                     },
                     "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "lodash._shimkeys@~2.4.1",
+                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash._objecttypes": {
                   "version": "2.4.1",
-                  "from": "lodash._objecttypes@~2.4.1",
+                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                 }
               }
             },
             "event-stream": {
               "version": "3.1.7",
-              "from": "event-stream@~3.1.0",
+              "from": "event-stream@>=3.1.0 <3.2.0",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@~2.3.1",
+                  "from": "through@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "duplexer@~0.1.1",
+                  "from": "duplexer@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "from@~0",
+                  "from": "from@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "map-stream@~0.1.0",
+                  "from": "map-stream@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
@@ -1196,12 +1196,12 @@
                 },
                 "split": {
                   "version": "0.2.10",
-                  "from": "split@0.2",
+                  "from": "split@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@~0.0.4",
+                  "from": "stream-combiner@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
@@ -1222,7 +1222,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.2.1",
-          "from": "lodash@~2.2.1",
+          "from": "lodash@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
         }
       }
@@ -1239,27 +1239,27 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.11.3",
-          "from": "jscs@~1.11.0",
+          "from": "jscs@>=1.11.0 <1.12.0",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.11.3.tgz",
           "dependencies": {
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@~0.3.1",
+              "from": "cli-table@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "colors@~1.0.3",
+              "from": "colors@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "esprima": {
               "version": "1.2.4",
-              "from": "esprima@~1.2.4",
+              "from": "esprima@>=1.2.4 <1.3.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
             },
             "esprima-harmony-jscs": {
@@ -1269,44 +1269,44 @@
             },
             "estraverse": {
               "version": "1.9.1",
-              "from": "estraverse@~1.9.1",
+              "from": "estraverse@>=1.9.1 <1.10.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.1.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.2",
+              "from": "exit@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "4.3.5",
-              "from": "glob@~4.3.5",
+              "from": "glob@>=4.3.5 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -1315,37 +1315,37 @@
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "lodash.assign@~3.0.0",
+              "from": "lodash.assign@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.0.1",
-                  "from": "lodash._baseassign@^3.0.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.0.1.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.0",
-                      "from": "lodash._basecopy@^3.0.0",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
                     },
                     "lodash.keys": {
                       "version": "3.0.3",
-                      "from": "lodash.keys@^3.0.0",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.3.tgz",
                       "dependencies": {
                         "lodash.isarguments": {
                           "version": "3.0.0",
-                          "from": "lodash.isarguments@^3.0.0",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.0",
-                          "from": "lodash.isarray@^3.0.0",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
                         },
                         "lodash.isnative": {
                           "version": "3.0.0",
-                          "from": "lodash.isnative@^3.0.0",
+                          "from": "lodash.isnative@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
                         }
                       }
@@ -1354,17 +1354,17 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.0.0",
-                  "from": "lodash._createassigner@^3.0.0",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.0.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.0",
-                      "from": "lodash._bindcallback@^3.0.0",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.1",
-                      "from": "lodash._isiterateecall@^3.0.0",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.1.tgz"
                     }
                   }
@@ -1373,17 +1373,17 @@
             },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@~2.0.1",
+              "from": "minimatch@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -1397,39 +1397,39 @@
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@~0.2.14",
+              "from": "prompt@>=0.2.14 <0.3.0",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.3.0",
-                  "from": "pkginfo@0.x.x",
+                  "from": "pkginfo@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "read": {
                   "version": "1.0.5",
-                  "from": "read@1.0.x",
+                  "from": "read@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.4",
-                      "from": "mute-stream@~0.0.4",
+                      "from": "mute-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                     }
                   }
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "revalidator@0.1.x",
+                  "from": "revalidator@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@0.2.x",
+                  "from": "utile@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.9",
+                      "from": "async@>=0.2.9 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
@@ -1439,12 +1439,12 @@
                     },
                     "i": {
                       "version": "0.3.2",
-                      "from": "i@0.3.x",
+                      "from": "i@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "mkdirp@0.x.x",
+                      "from": "mkdirp@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
@@ -1456,49 +1456,49 @@
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "ncp@0.4.x",
+                      "from": "ncp@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@2.x.x",
+                      "from": "rimraf@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@0.8.x",
+                  "from": "winston@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@0.2.x",
+                      "from": "async@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "colors@0.6.x",
+                      "from": "colors@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "cycle@1.0.x",
+                      "from": "cycle@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "eyes@0.1.x",
+                      "from": "eyes@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.1",
-                      "from": "isstream@0.1.x",
+                      "from": "isstream@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "stack-trace@0.0.x",
+                      "from": "stack-trace@>=0.0.0 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -1507,40 +1507,40 @@
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@~1.0.2",
+              "from": "strip-json-comments@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "supports-color": {
               "version": "1.2.0",
-              "from": "supports-color@~1.2.0",
+              "from": "supports-color@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@~0.3.4",
+              "from": "vow-fs@>=0.3.4 <0.4.0",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@^1.4.2",
+                  "from": "node-uuid@>=1.4.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.1",
-                  "from": "vow-queue@^0.4.1",
+                  "from": "vow-queue@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
                 }
               }
             },
             "xmlbuilder": {
-              "version": "2.5.1",
-              "from": "xmlbuilder@~2.5.0",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.5.1.tgz",
+              "version": "2.5.2",
+              "from": "xmlbuilder@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.5.2.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.1.0",
-                  "from": "lodash@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.1.0.tgz"
+                  "version": "3.2.0",
+                  "from": "lodash@>=3.2.0 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                 }
               }
             }
@@ -1548,12 +1548,12 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "vow": {
           "version": "0.4.8",
-          "from": "vow@~0.4.1",
+          "from": "vow@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.8.tgz"
         }
       }
@@ -1570,32 +1570,32 @@
           "dependencies": {
             "nomnom": {
               "version": "1.8.1",
-              "from": "nomnom@>= 1.5.x",
+              "from": "nomnom@>=1.5.0",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@~1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "chalk@~0.4.0",
+                  "from": "chalk@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "from": "has-color@~0.1.0",
+                      "from": "has-color@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "ansi-styles@~1.0.0",
+                      "from": "ansi-styles@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "strip-ansi@~0.1.0",
+                      "from": "strip-ansi@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -1604,7 +1604,7 @@
             },
             "JSV": {
               "version": "4.0.2",
-              "from": "JSV@>= 4.0.x",
+              "from": "JSV@>=4.0.0",
               "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
             }
           }
@@ -1618,27 +1618,27 @@
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
+          "from": "cli-color@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@~0.9.2",
+              "from": "es5-ext@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
+              "from": "memoizee@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2",
+                  "from": "event-emitter@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@0.1.x",
+                  "from": "next-tick@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -1647,22 +1647,22 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "grunt": {
           "version": "0.4.5",
-          "from": "grunt@^0.4.4",
+          "from": "grunt@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "dependencies": {
             "async": {
               "version": "0.1.22",
-              "from": "async@~0.1.22",
+              "from": "async@>=0.1.22 <0.2.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
             },
             "coffee-script": {
               "version": "1.3.3",
-              "from": "coffee-script@~1.3.3",
+              "from": "coffee-script@>=1.3.3 <1.4.0",
               "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
             },
             "dateformat": {
@@ -1672,37 +1672,37 @@
             },
             "eventemitter2": {
               "version": "0.4.14",
-              "from": "eventemitter2@~0.4.13",
+              "from": "eventemitter2@>=0.4.13 <0.5.0",
               "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
             },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@~0.1.2",
+              "from": "findup-sync@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@~3.2.9",
+                  "from": "glob@>=3.2.9 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@0.3",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -1711,139 +1711,139 @@
                 },
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.1.21",
-              "from": "glob@~3.1.21",
+              "from": "glob@>=3.1.21 <3.2.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1.2.0",
+                  "from": "graceful-fs@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 },
                 "inherits": {
                   "version": "1.0.0",
-                  "from": "inherits@1",
+                  "from": "inherits@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 }
               }
             },
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@~0.2.3",
+              "from": "hooker@>=0.2.3 <0.3.0",
               "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@~0.2.11",
+              "from": "iconv-lite@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@~0.2.12",
+              "from": "minimatch@>=0.2.12 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@~1.0.10",
+              "from": "nopt@>=1.0.10 <1.1.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@1",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.8",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "lodash": {
               "version": "0.9.2",
-              "from": "lodash@~0.9.2",
+              "from": "lodash@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
             },
             "underscore.string": {
               "version": "2.2.1",
-              "from": "underscore.string@~2.2.1",
+              "from": "underscore.string@>=2.2.1 <2.3.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
             },
             "which": {
               "version": "1.0.8",
-              "from": "which@~1.0.5",
+              "from": "which@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
             },
             "js-yaml": {
               "version": "2.0.5",
-              "from": "js-yaml@~2.0.5",
+              "from": "js-yaml@>=2.0.5 <2.1.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
+                  "from": "argparse@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                   "dependencies": {
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0",
+                      "from": "underscore.string@>=2.4.0 <2.5.0",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2",
+                  "from": "esprima@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.1",
+              "from": "exit@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "getobject": {
               "version": "0.1.0",
-              "from": "getobject@~0.1.0",
+              "from": "getobject@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
             },
             "grunt-legacy-util": {
               "version": "0.2.0",
-              "from": "grunt-legacy-util@~0.2.0",
+              "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
             },
             "grunt-legacy-log": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log@~0.1.0",
+              "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.3",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
@@ -1852,22 +1852,22 @@
         },
         "request": {
           "version": "2.53.0",
-          "from": "request@^2.34.0",
+          "from": "request@>=2.53.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@~0.9.0",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -1877,12 +1877,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1891,56 +1891,56 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@~0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@~0.5.0",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@~0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@~0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@~2.0.1",
+              "from": "mime-types@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@~1.7.0",
+                  "from": "mime-db@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "qs": {
               "version": "2.3.3",
-              "from": "qs@~2.3.1",
+              "from": "qs@>=2.3.1 <2.4.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
@@ -1957,12 +1957,12 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -1979,44 +1979,44 @@
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@~0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@~2.3.0",
+              "from": "hawk@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.11.0",
-                  "from": "hoek@2.x.x",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@1.x.x",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@~0.0.5",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -2028,14 +2028,14 @@
             },
             "isstream": {
               "version": "0.1.1",
-              "from": "isstream@~0.1.1",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -2047,42 +2047,42 @@
       "dependencies": {
         "requirejs": {
           "version": "2.1.16",
-          "from": "requirejs@2.1.x",
+          "from": "requirejs@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.16.tgz"
         },
         "cheerio": {
           "version": "0.13.1",
-          "from": "cheerio@0.13.x",
+          "from": "cheerio@>=0.13.0 <0.14.0",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.4.0",
-              "from": "htmlparser2@~3.4.0",
+              "from": "htmlparser2@>=3.4.0 <3.5.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "domhandler@2.2",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.3.0",
-                  "from": "domutils@1.3",
+                  "from": "domutils@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "domelementtype@1",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -2092,12 +2092,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -2106,32 +2106,32 @@
             },
             "underscore": {
               "version": "1.5.2",
-              "from": "underscore@~1.5",
+              "from": "underscore@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@0.x",
+              "from": "entities@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "CSSselect@~0.4.0",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "CSSwhat@0.4",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "domutils@1.4",
+                  "from": "domutils@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@1",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
@@ -2142,29 +2142,29 @@
         },
         "almond": {
           "version": "0.2.9",
-          "from": "almond@0.2.x",
+          "from": "almond@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
         },
         "gzip-js": {
           "version": "0.3.2",
-          "from": "gzip-js@0.3.x",
+          "from": "gzip-js@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "dependencies": {
             "crc32": {
               "version": "0.2.2",
-              "from": "crc32@>= 0.2.2",
+              "from": "crc32@>=0.2.2",
               "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
             },
             "deflate-js": {
               "version": "0.2.3",
-              "from": "deflate-js@>= 0.2.2",
+              "from": "deflate-js@>=0.2.2",
               "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
             }
           }
         },
         "q": {
           "version": "0.8.12",
-          "from": "q@0.8.x",
+          "from": "q@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
         }
       }
@@ -2175,135 +2175,135 @@
       "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
     },
     "grunt-sass": {
-      "version": "0.17.0",
-      "from": "grunt-sass@0.17.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.17.0.tgz",
+      "version": "0.18.0",
+      "from": "grunt-sass@0.18.0",
+      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.18.0.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@^1.0.0",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@^1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.0",
-              "from": "set-immediate-shim@^1.0.0",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
             }
           }
         },
         "node-sass": {
-          "version": "1.2.3",
-          "from": "node-sass@1.2.3",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-1.2.3.tgz",
+          "version": "2.0.1",
+          "from": "node-sass@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.0.1.tgz",
           "dependencies": {
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.2",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            },
             "cross-spawn": {
               "version": "0.2.6",
-              "from": "cross-spawn@^0.2.3",
+              "from": "cross-spawn@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.6.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@^2.5.0",
+                  "from": "lru-cache@>=2.5.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "gaze@^0.5.1",
+              "from": "gaze@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "globule@~0.1.0",
+                  "from": "globule@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.1",
-                      "from": "lodash@~1.0.1",
+                      "from": "lodash@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "glob@~3.1.21",
+                      "from": "glob@>=3.1.21 <3.2.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "graceful-fs@~1.2.0",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.0",
-                          "from": "inherits@1",
+                          "from": "inherits@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -2313,45 +2313,45 @@
               }
             },
             "get-stdin": {
-              "version": "3.0.2",
-              "from": "get-stdin@^3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
-              "version": "2.1.0",
-              "from": "meow@^2.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
+              "version": "3.0.0",
+              "from": "meow@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.0.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.0.2",
-                      "from": "camelcase@^1.0.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.0",
-                      "from": "map-obj@^1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.0",
-                  "from": "indent-string@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "repeating": {
-                      "version": "1.1.1",
-                      "from": "repeating@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
+                      "version": "1.1.2",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.0",
-                          "from": "is-finite@^1.0.0",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                         }
                       }
@@ -2360,19 +2360,14 @@
                 },
                 "minimist": {
                   "version": "1.1.0",
-                  "from": "minimist@^1.1.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
-                },
-                "object-assign": {
-                  "version": "2.0.0",
-                  "from": "object-assign@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@^0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
@@ -2384,7 +2379,7 @@
             },
             "mocha": {
               "version": "2.1.0",
-              "from": "mocha@^2.0.1",
+              "from": "mocha@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
               "dependencies": {
                 "commander": {
@@ -2421,29 +2416,29 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.0",
+                      "from": "graceful-fs@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -2474,13 +2469,71 @@
             },
             "nan": {
               "version": "1.6.2",
-              "from": "nan@^1.3.0",
+              "from": "nan@>=1.6.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
             },
-            "object-assign": {
-              "version": "1.0.0",
-              "from": "object-assign@^1.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+            "npmconf": {
+              "version": "2.1.1",
+              "from": "npmconf@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.8",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.3",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                },
+                "nopt": {
+                  "version": "3.0.1",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
             },
             "replace-ext": {
               "version": "0.0.1",
@@ -2489,22 +2542,22 @@
             },
             "request": {
               "version": "2.53.0",
-              "from": "request@^2.48.0",
+              "from": "request@>=2.53.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@~0.9.0",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -2514,12 +2567,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -2528,56 +2581,56 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@~0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@~0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.9",
-                  "from": "mime-types@~2.0.1",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "mime-db@~1.7.0",
+                      "from": "mime-db@>=1.7.0 <1.8.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@~2.3.1",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
@@ -2594,12 +2647,12 @@
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -2616,44 +2669,44 @@
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@~0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@~2.3.0",
+                  "from": "hawk@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.11.0",
-                      "from": "hoek@2.x.x",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@2.x.x",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -2665,21 +2718,98 @@
                 },
                 "isstream": {
                   "version": "0.1.1",
-                  "from": "isstream@~0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
                 }
               }
             },
+            "sass-graph": {
+              "version": "1.0.3",
+              "from": "sass-graph@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.0.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.3.5",
+                  "from": "glob@>=4.3.4 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.1",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.0",
+              "from": "semver@>=4.2.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
+            },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@^0.3.0",
+              "from": "shelljs@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@^2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         }
       }
@@ -2696,53 +2826,53 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5",
+          "from": "chalk@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -2754,53 +2884,53 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.1.1",
-          "from": "debug@~2.1.0",
+          "from": "debug@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
           "dependencies": {
             "ms": {
@@ -2812,7 +2942,7 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
@@ -3003,7 +3133,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }
@@ -3020,49 +3150,49 @@
           "dependencies": {
             "esprima": {
               "version": "1.2.4",
-              "from": "esprima@1.2.x",
+              "from": "esprima@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.4.tgz"
             },
             "escodegen": {
               "version": "1.3.3",
-              "from": "escodegen@1.3.x",
+              "from": "escodegen@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.0.0",
-                  "from": "esutils@~1.0.0",
+                  "from": "esutils@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                 },
                 "estraverse": {
                   "version": "1.5.1",
-                  "from": "estraverse@~1.5.0",
+                  "from": "estraverse@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                 },
                 "esprima": {
                   "version": "1.1.1",
-                  "from": "esprima@~1.1.1",
+                  "from": "esprima@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                 }
               }
             },
             "handlebars": {
               "version": "1.3.0",
-              "from": "handlebars@1.3.x",
+              "from": "handlebars@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@~0.3",
+                  "from": "optimist@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "uglify-js@~2.3",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.6",
+                      "from": "async@>=0.2.6 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     }
                   }
@@ -3071,7 +3201,7 @@
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@0.5.x",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
@@ -3083,54 +3213,54 @@
             },
             "nopt": {
               "version": "3.0.1",
-              "from": "nopt@3.x",
+              "from": "nopt@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
             },
             "fileset": {
               "version": "0.1.5",
-              "from": "fileset@0.1.x",
+              "from": "fileset@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.4.0",
-                  "from": "minimatch@0.x",
+                  "from": "minimatch@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@3.x",
+                  "from": "glob@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@0.3",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -3141,49 +3271,49 @@
             },
             "which": {
               "version": "1.0.8",
-              "from": "which@1.0.x",
+              "from": "which@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@0.9.x",
+              "from": "async@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1.0.x",
+              "from": "abbrev@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             },
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@0.0.x",
+              "from": "wordwrap@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "resolve": {
               "version": "0.7.4",
-              "from": "resolve@0.7.x",
+              "from": "resolve@>=0.7.0 <0.8.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "js-yaml": {
               "version": "3.2.6",
-              "from": "js-yaml@3.x",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.6.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
+                  "from": "argparse@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                   "dependencies": {
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0",
+                      "from": "underscore.string@>=2.4.0 <2.5.0",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2",
+                  "from": "esprima@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
@@ -3260,27 +3390,27 @@
               "dependencies": {
                 "adm-zip": {
                   "version": "0.4.7",
-                  "from": "adm-zip@^0.4.3",
+                  "from": "adm-zip@>=0.4.3 <0.5.0",
                   "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
                 },
                 "extname": {
                   "version": "0.1.5",
-                  "from": "extname@^0.1.1",
+                  "from": "extname@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.5.tgz",
                   "dependencies": {
                     "ext-list": {
                       "version": "0.2.0",
-                      "from": "ext-list@^0.2.0",
+                      "from": "ext-list@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
                       "dependencies": {
                         "got": {
                           "version": "0.2.0",
-                          "from": "got@^0.2.0",
+                          "from": "got@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
                           "dependencies": {
                             "object-assign": {
                               "version": "0.3.1",
-                              "from": "object-assign@^0.3.0",
+                              "from": "object-assign@>=0.3.0 <0.4.0",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
                             }
                           }
@@ -3289,70 +3419,70 @@
                     },
                     "underscore.string": {
                       "version": "2.3.3",
-                      "from": "underscore.string@~2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                     }
                   }
                 },
                 "get-stdin": {
                   "version": "0.1.0",
-                  "from": "get-stdin@^0.1.0",
+                  "from": "get-stdin@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
                 },
                 "map-key": {
                   "version": "0.1.5",
-                  "from": "map-key@^0.1.1",
+                  "from": "map-key@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.5.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "2.4.1",
-                      "from": "lodash@^2.4.1",
+                      "from": "lodash@>=2.4.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                     },
                     "underscore.string": {
                       "version": "2.4.0",
-                      "from": "underscore.string@^2.3.3",
+                      "from": "underscore.string@>=2.3.3 <3.0.0",
                       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@^0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "nopt": {
                   "version": "2.2.1",
-                  "from": "nopt@^2.2.0",
+                  "from": "nopt@>=2.2.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.5",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@^2.2.2",
+                  "from": "rimraf@>=2.2.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@^0.0.4",
+                  "from": "stream-combiner@>=0.0.4 <0.0.5",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "dependencies": {
                     "duplexer": {
                       "version": "0.1.1",
-                      "from": "duplexer@~0.1.1",
+                      "from": "duplexer@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                     }
                   }
                 },
                 "tar": {
                   "version": "0.1.20",
-                  "from": "tar@^0.1.18",
+                  "from": "tar@>=0.1.18 <0.2.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
                   "dependencies": {
                     "block-stream": {
@@ -3362,17 +3492,17 @@
                     },
                     "fstream": {
                       "version": "0.1.31",
-                      "from": "fstream@~0.1.28",
+                      "from": "fstream@>=0.1.28 <0.2.0",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "3.0.5",
-                          "from": "graceful-fs@~3.0.2",
+                          "from": "graceful-fs@>=3.0.2 <3.1.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                         },
                         "mkdirp": {
                           "version": "0.5.0",
-                          "from": "mkdirp@0.5",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
@@ -3386,19 +3516,19 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "tempfile": {
                   "version": "0.1.3",
-                  "from": "tempfile@^0.1.2",
+                  "from": "tempfile@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
                   "dependencies": {
                     "uuid": {
                       "version": "1.4.2",
-                      "from": "uuid@~1.4.0",
+                      "from": "uuid@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
                     }
                   }
@@ -3426,59 +3556,59 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@^2.2.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
           "version": "1.0.2",
-          "from": "topo@1.x.x",
+          "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
         },
         "isemail": {
           "version": "1.1.1",
-          "from": "isemail@1.x.x",
+          "from": "isemail@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         },
         "moment": {
           "version": "2.9.0",
-          "from": "moment@2.x.x",
+          "from": "moment@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
         }
       }
     },
     "jshint": {
       "version": "2.6.0",
-      "from": "jshint@",
+      "from": "jshint@*",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.0.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.5",
-          "from": "cli@0.6.x",
+          "from": "cli@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~ 3.2.1",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -3489,44 +3619,44 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@1.1.x",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@^0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@0.1.x",
+          "from": "exit@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@3.8.x",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@2.3",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@1.5",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@~1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -3535,17 +3665,17 @@
             },
             "domelementtype": {
               "version": "1.1.3",
-              "from": "domelementtype@1",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@1.1",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -3555,53 +3685,53 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@1.0",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@1.0.x",
+          "from": "minimatch@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.3.0",
-          "from": "shelljs@0.3.x",
+          "from": "shelljs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@1.0.x",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@1.6.x",
+          "from": "underscore@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
@@ -3613,68 +3743,68 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.1",
-          "from": "log-symbols@^1.0.0",
+          "from": "log-symbols@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz"
         },
         "string-length": {
           "version": "1.0.0",
-          "from": "string-length@^1.0.0",
+          "from": "string-length@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
           "dependencies": {
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@^2.0.0",
+              "from": "strip-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.0",
-                  "from": "ansi-regex@^1.0.0",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
                 }
               }
@@ -3683,7 +3813,7 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
@@ -3695,44 +3825,44 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.2.1",
-          "from": "findup-sync@^0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
           "dependencies": {
             "glob": {
               "version": "4.3.5",
-              "from": "glob@~4.3.0",
+              "from": "glob@>=4.3.0 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.1",
-                  "from": "minimatch@^2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -3746,12 +3876,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3762,39 +3892,39 @@
         },
         "multimatch": {
           "version": "2.0.0",
-          "from": "multimatch@^2.0.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@^1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@^1.0.1",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.1",
-              "from": "minimatch@^2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -3817,85 +3947,85 @@
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@^1.0.0",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.2",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "strftime@~0.8.2",
+              "from": "strftime@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "symbol@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@^1.2.0",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
@@ -3907,7 +4037,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@~0.9.x",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         }
       }
@@ -3919,73 +4049,73 @@
       "dependencies": {
         "buildmail": {
           "version": "1.2.0",
-          "from": "buildmail@^1.2.0",
+          "from": "buildmail@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-1.2.0.tgz",
           "dependencies": {
             "addressparser": {
               "version": "0.3.2",
-              "from": "addressparser@^0.3.1",
+              "from": "addressparser@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
-              "from": "libbase64@^0.1.0",
+              "from": "libbase64@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
             },
             "libqp": {
               "version": "0.1.1",
-              "from": "libqp@^0.1.1",
+              "from": "libqp@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz"
             }
           }
         },
         "hyperquest": {
           "version": "0.3.0",
-          "from": "hyperquest@^0.3.0",
+          "from": "hyperquest@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-0.3.0.tgz",
           "dependencies": {
             "through": {
               "version": "2.2.7",
-              "from": "through@~2.2.0",
+              "from": "through@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
             },
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@~0.1.0",
+              "from": "duplexer@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             }
           }
         },
         "libmime": {
           "version": "0.1.7",
-          "from": "libmime@^0.1.5",
+          "from": "libmime@>=0.1.5 <0.2.0",
           "resolved": "https://registry.npmjs.org/libmime/-/libmime-0.1.7.tgz",
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.7",
-              "from": "iconv-lite@^0.4.4",
+              "from": "iconv-lite@>=0.4.4 <0.5.0",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
-              "from": "libbase64@^0.1.0",
+              "from": "libbase64@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
             },
             "libqp": {
               "version": "0.1.1",
-              "from": "libqp@^0.1.1",
+              "from": "libqp@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/libqp/-/libqp-0.1.1.tgz"
             }
           }
         },
         "nodemailer-direct-transport": {
           "version": "1.0.0",
-          "from": "nodemailer-direct-transport@^1.0.0",
+          "from": "nodemailer-direct-transport@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-1.0.0.tgz",
           "dependencies": {
             "smtp-connection": {
               "version": "0.1.7",
-              "from": "smtp-connection@^0.1.5",
+              "from": "smtp-connection@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-0.1.7.tgz"
             }
           }
@@ -3999,12 +4129,12 @@
       "dependencies": {
         "nodemailer-wellknown": {
           "version": "0.1.5",
-          "from": "nodemailer-wellknown@^0.1.1",
+          "from": "nodemailer-wellknown@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.5.tgz"
         },
         "smtp-connection": {
           "version": "1.1.0",
-          "from": "smtp-connection@^1.0.0",
+          "from": "smtp-connection@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz"
         }
       }
@@ -4046,12 +4176,12 @@
           "dependencies": {
             "split": {
               "version": "0.3.3",
-              "from": "split@~0.3",
+              "from": "split@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@2",
+                  "from": "through@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
@@ -4059,9 +4189,9 @@
           }
         },
         "semver": {
-          "version": "4.2.2",
-          "from": "semver@^4.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+          "version": "4.3.0",
+          "from": "semver@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.0.tgz"
         }
       }
     },
@@ -4072,24 +4202,24 @@
       "dependencies": {
         "xtend": {
           "version": "2.1.2",
-          "from": "xtend@~2.1.1",
+          "from": "xtend@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "dependencies": {
             "object-keys": {
               "version": "0.4.0",
-              "from": "object-keys@~0.4.0",
+              "from": "object-keys@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "argh": {
           "version": "0.1.3",
-          "from": "argh@~0.1.1",
+          "from": "argh@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.3.tgz"
         }
       }
@@ -4126,22 +4256,22 @@
       "dependencies": {
         "request": {
           "version": "2.53.0",
-          "from": "request@^2.34.0",
+          "from": "request@>=2.53.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@~0.9.0",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -4151,12 +4281,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4165,56 +4295,56 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@~0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@~0.5.0",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@~0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@~0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime-types": {
               "version": "2.0.9",
-              "from": "mime-types@~2.0.1",
+              "from": "mime-types@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.7.0",
-                  "from": "mime-db@~1.7.0",
+                  "from": "mime-db@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "qs": {
               "version": "2.3.3",
-              "from": "qs@~2.3.1",
+              "from": "qs@>=2.3.1 <2.4.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
@@ -4231,12 +4361,12 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -4253,44 +4383,44 @@
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@~0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@~2.3.0",
+              "from": "hawk@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.11.0",
-                  "from": "hoek@2.x.x",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@1.x.x",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@~0.0.5",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
@@ -4302,7 +4432,7 @@
             },
             "isstream": {
               "version": "0.1.1",
-              "from": "isstream@~0.1.1",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             }
           }
@@ -4315,13 +4445,13 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
     },
     "wreck": {
-      "version": "5.1.0",
-      "from": "wreck@5.1.0",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.1.0.tgz",
+      "version": "5.2.0",
+      "from": "wreck@5.2.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz",
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@2.x.x",
+          "from": "hoek@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "underscore.string": "3.0.3",
     "url2png": "6.0.2",
     "uuid": "2.0.1",
-    "wreck": "5.1.0"
+    "wreck": "5.2.0"
   },
   "devDependencies": {
     "grunt-autoprefixer": "2.2.0",
@@ -45,7 +45,7 @@
     "grunt-nsp-shrinkwrap": "0.0.3",
     "grunt-requirejs": "0.4.2",
     "grunt-rev": "0.1.0",
-    "grunt-sass": "0.17.0",
+    "grunt-sass": "0.18.0",
     "grunt-template": "0.2.3",
     "grunt-todo": "0.4.0",
     "grunt-usemin": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "underscore": "1.7.0",
     "underscore.string": "3.0.3",
     "url2png": "6.0.2",
-    "uuid": "2.0.1",
-    "wreck": "5.2.0"
+    "uuid": "2.0.1"
   },
   "devDependencies": {
     "grunt-autoprefixer": "2.2.0",


### PR DESCRIPTION
Updating [**grunt-sass**](https://github.com/sindresorhus/grunt-sass/) ([CHANGELOG](https://github.com/sindresorhus/grunt-sass/compare/v0.17.0...v0.18.0)) and [**wreck**](https://github.com/hapijs/wreck/) ([CHANGELOG](https://github.com/hapijs/wreck/compare/v5.1.0...v5.2.0)) dependencies.

Chronicle should now run on iojs and Node 0.12! (tested w/ iojs-v1.2.0 and v0.12.0)!

Fixes #321