### PR TITLE
docs(readme): update README to use current bin scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ Run the following in separate terminal windows/tabs:
 
 If you just want to test something quickly with a small, known test data set:
 
-1. Run `server/db/create_db.js` to drop and re-create the local Postgres database.
-2. To enable test data, ensure the `testUser.enabled` config option is set in `config/local.json`.
+1. Run `./bin/create_db.sh` to drop and re-create the local Postgres database.
+2. Run `./bin/migrate.js` to apply any Postgres migrations specified in the `server/db/migrations/` directory.
+3. To enable test data, ensure the `testUser.enabled` config option is set in `config/local.json`.
   - You can use the default id and email (defined in `server/config.js`), or set them yourself.
     You can set the values via env vars or config values.
     See `server/config.js` for the defaults and which config values or env vars to use.
-3. Run `server/db/create_test_data.js` to create a dummy user and a few dummy visits.
-  - The number of records to create is configurable; invoke it with `--help` for details.
+4. Run `./bin/create_test_data.js` to create a dummy user and a few dummy visits.
+  - The created dummy visits which will be created can be found in the `config/test-urls.js` file.
 
 ## Learn More
 * Tumblr: http://mozillachronicle.tumblr.com/

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -8,15 +8,19 @@
 // TODO add 'next' and 'prev' convenience methods?
 // TODO bring back commander, I guess
 
+'use strict';
+
 var fs = require('fs');
+var path = require('path');
 var log = require('../server/logger')('bin.migrate');
-var migrator = require('../server/db/migrator.js');
+var migrator = require('../server/db/migrator');
 var targetLevel = parseInt(process.argv[2], 10);
+var files;
 
 // if no args were passed, or if the arg wasn't an integer,
 // then, by default, use the highest defined patch level
 if (isNaN(targetLevel)) {
-  files = fs.readdirSync(__dirname + '/../server/db/migrations');
+  files = fs.readdirSync(path.join(__dirname , '..', 'server', 'db', 'migrations'));
   var max = 0;
   files.forEach(function(file) {
     // assume files are of the conventional form 'patch-n-m.sql'
@@ -27,6 +31,7 @@ if (isNaN(targetLevel)) {
   });
   targetLevel = max;
 }
+
 migrator(targetLevel)
   .done(function onSuccess(resp) {
     log.info('migration succeeded');

--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -6,12 +6,12 @@ module.exports = function (grunt) {
   'use strict';
 
   grunt.config('copyright', {
+    options: {
+      pattern: /This Source Code Form is subject to the terms of the Mozilla Public/
+    },
     app: {
-      options: {
-        pattern: /This Source Code Form is subject to the terms of the Mozilla Public/
-      },
       src: [
-        '{,app/**/,grunttasks/**/,server/**/,tests/**/}*.js',
+        '{,app/**/,bin/**/,grunttasks/**/,server/**/,tests/**/}*.js',
         '!app/bower_components/**'
       ]
     }

--- a/grunttasks/jscs.js
+++ b/grunttasks/jscs.js
@@ -6,12 +6,14 @@ module.exports = function (grunt) {
   'use strict';
 
   grunt.config('jscs', {
-    src: [
-      '{,app/**/,grunttasks/**/,server/**/,tests/**/}*.js',
-      '!app/bower_components/**'
-    ],
     options: {
       config: '.jscsrc'
+    },
+    app: {
+      src: [
+        '{,app/**/,bin/**/,grunttasks/**/,server/**/,tests/**/}*.js',
+        '!app/bower_components/**'
+      ]
     }
   });
 };

--- a/grunttasks/jshint.js
+++ b/grunttasks/jshint.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
     },
     app: {
       src: [
-        '{,app/**/,grunttasks/**/,server/**/,tests/**/}*.js',
+        '{,app/**/,bin/**/,grunttasks/**/,server/**/,tests/**/}*.js',
         '!app/bower_components/**'
       ]
     }

--- a/grunttasks/jsonlint.js
+++ b/grunttasks/jsonlint.js
@@ -6,16 +6,10 @@ module.exports = function (grunt) {
   'use strict';
 
   grunt.config('jsonlint', {
-    config: {
-      src: [
-        '.bowerrc',
-        '.jshintrc',
-        '.jscsrc'
-      ]
-    },
     app: {
       src: [
-        '{,app/**/,grunttasks/**/,server/**/,tests/**/}*.json',
+        '{.bowerrc,.jshintrc,.jscsrc}',
+        '{,app/**/,bin/**/,grunttasks/**/,server/**/,tests/**/}*.json',
         'config/*.{json,example}',
         '!app/bower_components/**'
       ]


### PR DESCRIPTION
Updated README.md to mention the new location of the database scripts in ./bin/.
Also noticed that we weren't linting any of the JavaScript scripts in /bin/ since there weren't any previously.

Fixes #316 