### PR TITLE
chore(sass): Add a convict flag to specify Sass output style

### DIFF
--- a/config/local.json.example
+++ b/config/local.json.example
@@ -41,5 +41,6 @@
   "server_oauth_tokenEndpoint": "https://oauth-latest.dev.lcip.org/v1/token",
   "server_oauth_profileEndpoint": "https://latest.dev.lcip.org/profile/v1/profile",
   "testUser_enabled": true,
-  "addon_firefox_url": ""
+  "addon_firefox_url": "",
+  "sass_outputStyle": "nested"
 }

--- a/grunttasks/sass.js
+++ b/grunttasks/sass.js
@@ -5,10 +5,12 @@
 module.exports = function (grunt) {
   'use strict';
 
+  var config = require('../server/config');
+
   grunt.config('sass', {
     options: {
       imagePath: '/images',
-      outputStyle: 'compressed',
+      outputStyle: config.get('sass_outputStyle'),
       precision: 3,
       sourceMap: true
     },

--- a/server/config.js
+++ b/server/config.js
@@ -308,6 +308,11 @@ var conf = convict({
     default: true,
     format: Boolean
   },
+  sass_outputStyle: {
+    doc: 'Sass output style for generated CSS',
+    format: ['nested', 'compressed'],
+    default: 'compressed'
+  },
   addon_firefox_url: {
     doc: 'Firefox Add-on URL',
     format: String,


### PR DESCRIPTION
Added a useless knob to control your Sass `outputStyle`. Possibly only useful to me and @johngruen (or anybody else dabbling in CSS who doesn't want to read minimized code).

The output is still compressed/minimized by default, but you can easily override locally by setting the `"sass_outputStyle": "nested"` in your config/local.json file.

Fixes #301 