### PR TITLE
refactor(db): Change the test data time interval so we see more date headings

### DIFF
--- a/bin/create_test_data.js
+++ b/bin/create_test_data.js
@@ -14,6 +14,8 @@ var user = require('../server/models/user');
 var visitsController = require('../server/controllers/visits');
 var testUrls = require('../config/test-urls');
 
+var HOURS_IN_MS = 1000 * 60 * 60;
+
 if (!config.get('testUser_enabled')) {
   throw new Error('To create test data, you must set testUser.enabled in the config.');
 }
@@ -33,7 +35,7 @@ function createTestUser(cb) {
 function createTestData(cb) {
   var userId = config.get('testUser_id');
   // we'll use this date as a starting point for generating records. Each successive
-  // record will be a number of seconds in the future.
+  // record will be a number of hours in the future.
   var historyDate = new Date('2015-01-01T21:26:23.795Z');
 
   function generateTestRequest(item, n) {
@@ -44,7 +46,7 @@ function createTestData(cb) {
       payload: {
         url: item.url,
         title: item.title,
-        visitedAt: new Date(historyDate.getTime() + (1000 * 60 * n)).toJSON()
+        visitedAt: new Date(historyDate.getTime() + (5 * HOURS_IN_MS * n)).toJSON()
       }
     };
   }


### PR DESCRIPTION
Each successive test data visit should be +5 hours later than the previous one, giving us 5-6 entries per date heading.

FWIW, 5 [hours] is a magically random number that I made up with no significance, apart from using 2, 3, 4, 6, or 8 were all divisible by 24, giving us the exact same numbers of entries per day. Or we could increase this to an equally arbitrary 7 or 9 hours difference, if that floats your collective boats.

Fixes #345