### PR TITLE
fix(visit): Change date heading to use day of month with ordinal

### DIFF
--- a/app/scripts/views/visits/date_divider.js
+++ b/app/scripts/views/visits/date_divider.js
@@ -35,7 +35,7 @@ define([
       } else if (diff === -1) {
         formattedDate = 'Yesterday';
       } else {
-        formattedDate = this.date.format('MMMM do');
+        formattedDate = this.date.format('MMMM Do');
       }
 
       return formattedDate;


### PR DESCRIPTION
Per http://momentjs.com/docs/#/parsing/string-format/

| Input | Example | Description |
|----:|----|----|
| `Do` | `1st..31st` | Day of month with ordinal |

Fixes #348 