### PR TITLE
feat(docs): add a /docs route using Lout

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -160,7 +160,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -172,7 +172,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -347,7 +347,7 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@^0.4.4",
+      "from": "grunt@~0.4.2",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
@@ -474,7 +474,7 @@
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
@@ -556,9 +556,9 @@
       "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-2.2.0.tgz",
       "dependencies": {
         "autoprefixer-core": {
-          "version": "5.1.5",
+          "version": "5.1.6",
           "from": "autoprefixer-core@^5.0.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.6.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.2.0",
@@ -571,9 +571,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.0.1.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000075",
-              "from": "caniuse-db@^1.0.30000065",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000075.tgz"
+              "version": "1.0.30000077",
+              "from": "caniuse-db@^1.0.30000077",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000077.tgz"
             },
             "postcss": {
               "version": "4.0.4",
@@ -608,7 +608,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.0",
+          "from": "chalk@~0.5",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -673,7 +673,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -693,7 +693,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -705,7 +705,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -1544,7 +1544,7 @@
               "dependencies": {
                 "lodash": {
                   "version": "3.2.0",
-                  "from": "lodash@~3.2.0",
+                  "from": "lodash@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                 }
               }
@@ -1674,7 +1674,7 @@
         },
         "grunt": {
           "version": "0.4.5",
-          "from": "grunt@^0.4.4",
+          "from": "grunt@~0.4.2",
           "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "dependencies": {
             "async": {
@@ -2257,7 +2257,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@^0.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -2428,7 +2428,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@1.0.2",
+                  "from": "escape-string-regexp@^1.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "glob": {
@@ -3322,26 +3322,31 @@
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "js-yaml": {
-              "version": "3.2.6",
+              "version": "3.2.7",
               "from": "js-yaml@3.x",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
               "dependencies": {
                 "argparse": {
-                  "version": "0.1.16",
-                  "from": "argparse@~ 0.1.11",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+                  "version": "1.0.0",
+                  "from": "argparse@~ 1.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.0.tgz",
                   "dependencies": {
-                    "underscore.string": {
-                      "version": "2.4.0",
-                      "from": "underscore.string@~2.4.0",
-                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                    "lodash": {
+                      "version": "3.2.0",
+                      "from": "lodash@^3.2.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@~1.0.2",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                     }
                   }
                 },
                 "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@~ 1.0.2",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                  "version": "2.0.0",
+                  "from": "esprima@~ 2.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
                 }
               }
             }
@@ -3583,7 +3588,7 @@
       "dependencies": {
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@^2.2.x",
+          "from": "hoek@2.x.x",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
         "topo": {
@@ -3610,7 +3615,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -3630,7 +3635,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3642,7 +3647,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3807,6 +3812,78 @@
         }
       }
     },
+    "lout": {
+      "version": "6.2.0",
+      "from": "lout@6.2.0",
+      "resolved": "https://registry.npmjs.org/lout/-/lout-6.2.0.tgz",
+      "dependencies": {
+        "handlebars": {
+          "version": "3.0.0",
+          "from": "handlebars@^3.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@^0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.1",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@^0.1.40",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@~2.3",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@0.2.x",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@~0.3.5",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@~0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hoek": {
+          "version": "2.11.0",
+          "from": "hoek@2.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+        }
+      }
+    },
     "mozlog": {
       "version": "1.0.2",
       "from": "mozlog@1.0.2",
@@ -3839,7 +3916,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -3851,7 +3928,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -3948,7 +4025,7 @@
             },
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@~0.1.1",
+              "from": "duplexer@~0.1.0",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             }
           }
@@ -4118,7 +4195,7 @@
       "dependencies": {
         "request": {
           "version": "2.53.0",
-          "from": "request@^2.34.0",
+          "from": "request@>=2.53.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
             "bl": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "husky": "0.6.2",
     "intern": "2.2.2",
     "jshint-stylish": "1.0.0",
-    "load-grunt-tasks": "3.1.0"
+    "load-grunt-tasks": "3.1.0",
+    "lout": "6.2.0"
   },
   "engines": {
     "node": ">=0.10.33"

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@
 var Hapi = require('hapi');
 var HapiAuthCookie = require('hapi-auth-cookie');
 var Bell = require('bell');
+var Lout = require('lout');
 var pg = require('pg');
 
 var config = require('./config');
@@ -37,7 +38,8 @@ server.connection({
 
 server.register([
   HapiAuthCookie,
-  Bell
+  Bell,
+  Lout
 ], function (err) {
   if (err) {
     log.warn('failed to load plugin: ' + err);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -19,7 +19,8 @@ var authRoutes = [{
       'hapi-auth-cookie': {
         redirectTo: false // don't redirect users who don't have a session
       }
-    }
+    },
+    tags: ['auth']
   }
 }, {
   method: 'GET',
@@ -29,7 +30,8 @@ var authRoutes = [{
     auth: {
       strategy: 'session',
       mode: 'try'
-    }
+    },
+    tags: ['auth']
   }
 }, {
   // Bell uses the same endpoint for both the start and redirect
@@ -43,6 +45,7 @@ var authRoutes = [{
       strategy: 'oauth',
       mode: 'try'
     },
+    tags: ['auth']
   }
 }];
 

--- a/server/routes/base.js
+++ b/server/routes/base.js
@@ -24,15 +24,21 @@ var baseRoutes = [{
         redirectTo: false // don't redirect users who don't have a session
       }
     },
+    description: 'Serves the welcome page or home page.',
+    tags: ['home']
   }
 }, {
   method: 'GET',
   path: '/{param*}',
-  handler: {
-    directory: {
-      path: STATIC_PATH,
-      listing: config.get('server_staticDirListing')
-    }
+  config: {
+    handler: {
+      directory: {
+        path: STATIC_PATH,
+        listing: config.get('server_staticDirListing')
+      }
+    },
+    description: 'A catch-all route for serving static files.',
+    tags: ['static']
   }
 }];
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,6 +7,7 @@
 var fs = require('fs');
 var routes = [];
 
+// Require each of the file in the current directory (except index.js).
 fs.readdirSync(__dirname).forEach(function(file) {
   if (file === 'index.js') { return; }
   routes = routes.concat(require('./' + file));

--- a/server/routes/ops.js
+++ b/server/routes/ops.js
@@ -87,6 +87,8 @@ module.exports = [{
       }, function (err) {
         reply(err.message).code(503);
       });
-    }
+    },
+    description: 'An endpoint for the OPs team to test server health.',
+    tags: ['ops']
   }
 }];

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -14,7 +14,8 @@ var profileRoutes = [{
   path: '/v1/profile',
   config: {
     handler: profileController.get,
-    auth: 'session'
+    auth: 'session',
+    tags: ['profile']
   }
 }];
 

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -21,7 +21,8 @@ var searchRoutes = [{
         q: Joi.string().required(),
         count: Joi.number().integer().min(1).max(100).default(25)
       }
-    }
+    },
+    tags: ['search']
   }
 }];
 

--- a/server/routes/ver.js
+++ b/server/routes/ver.js
@@ -10,6 +10,8 @@ module.exports = [{
   method: 'GET',
   path: '/ver.json',
   config: {
-    handler: verJsonController.get
+    handler: verJsonController.get,
+    description: 'Displays the Git SHAs for the deployed server.',
+    tags: ['ops']
   }
 }];

--- a/server/routes/visit.js
+++ b/server/routes/visit.js
@@ -19,7 +19,9 @@ var visitRoutes = [{
       params: {
         visitId: Joi.string().guid().required()
       }
-    }
+    },
+    description: 'Get a specific visit, by <code>visitId</code>.',
+    tags: ['visit']
   }
 }, {
   method: 'PUT',
@@ -37,7 +39,9 @@ var visitRoutes = [{
       params: {
         visitId: Joi.string().guid().required()
       }
-    }
+    },
+    description: 'Create a specific visit and set the specified <code>url</code>, <code>title</code>, <code>visitedAt</code> fields.',
+    tags: ['visit']
   }
 }, {
   method: 'DELETE',
@@ -49,7 +53,9 @@ var visitRoutes = [{
       params: {
         visitId: Joi.string().guid().required()
       }
-    }
+    },
+    description: 'Delete a specific visit, by <code>visitId</code>.',
+    tags: ['visit']
   }
 }];
 

--- a/server/routes/visits.js
+++ b/server/routes/visits.js
@@ -21,7 +21,9 @@ var visitsRoutes = [{
         count: Joi.number().integer().min(1).max(100).default(25),
         visitId: Joi.string().guid()
       }
-    }
+    },
+    description: 'Get <code>count</code> visits from the database, starting at <code>visitId</code>.',
+    tags: ['visits']
   }
 }, {
   method: 'POST',
@@ -37,7 +39,8 @@ var visitsRoutes = [{
         // client can optionally provide uuid
         visitId: Joi.string().guid()
       }
-    }
+    },
+    tags: ['visits']
   }
 }];
 


### PR DESCRIPTION
Adds a <http://localhost:8080/docs> route which shows some auto-generated route documentation using [**Lout**](https://www.npmjs.com/package/lout).

It ain't pretty, but _meh_.

Closes #108 