### PR TITLE
bug(db): specify TEMPLATE when creating db.

### DIFF
--- a/bin/create_db.sh
+++ b/bin/create_db.sh
@@ -15,7 +15,7 @@ psql -c "REASSIGN OWNED BY chronicle TO $PSQLUSER;" -U $PSQLUSER
 psql -c 'DROP USER IF EXISTS chronicle;' -U $PSQLUSER
 
 psql -c "CREATE USER chronicle WITH PASSWORD 'chronicle';" -U $PSQLUSER
-psql -c "CREATE DATABASE chronicle ENCODING 'UTF-8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';" -U $PSQLUSER
+psql -c "CREATE DATABASE chronicle ENCODING 'UTF-8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8' TEMPLATE template0;" -U $PSQLUSER
 psql -c 'GRANT ALL PRIVILEGES ON DATABASE chronicle to chronicle;' -U $PSQLUSER
 psql -c 'ALTER SCHEMA public OWNER TO chronicle;' -U $PSQLUSER
 


### PR DESCRIPTION
  By specifying the template, we avoid collation errors when running on clients
  that do not have the en_US locale.

  Fixes #367.
